### PR TITLE
Http error code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .DS_Store
 target
+*~
+

--- a/src/main/java/applicationContext.xml
+++ b/src/main/java/applicationContext.xml
@@ -15,4 +15,7 @@ The AODN/IMOS Portal is distributed under the terms of the GNU General Public Li
     <!-- TODO: can this be done using autowiring? -->
     <constructor-arg index="2" ref="CSVOutputFormat"/>
   </bean>
+
+    <!--  dispatcher -->
+    <bean id="dispatcher" class="org.geoserver.ows.DispatcherWithHttpStatus"/>
 </beans>

--- a/src/main/java/org/geoserver/ows/DispatcherWithHttpStatus.java
+++ b/src/main/java/org/geoserver/ows/DispatcherWithHttpStatus.java
@@ -1,0 +1,12 @@
+package org.geoserver.ows;
+
+import org.geoserver.platform.Service;
+import org.geoserver.platform.ServiceException;
+
+public class DispatcherWithHttpStatus extends org.geoserver.ows.Dispatcher {
+
+    void handleServiceException(ServiceException se, Service service, Request request) {
+        super.handleServiceException(se, service, request);
+        request.getHttpResponse().setStatus(500);
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/aodn/aodn-portal/issues/1097

This change means that whenever a `ServiceException` occurs, an HTTP status code of 500 will be returned to the client, instead of always 200 (which should play better with our squid caching).

Note the patch at http://jira.codehaus.org/browse/GEOS-4255 was not used for the following reasons:
- it's against an older version of geoserver than we are using (2.1.x)
- it touches many files, which would give it a large maintenance overhead if we were to maintain it ourselves.

So, this patch is much simpler, with the downside that 500 is _always_ return for errors (instead of the appropriate 400, 500 code, as in the patch) - but - this _should_ be good enough for us re squid.

Tested with the following URLs (connecting to a VM provisioned with 3-nec-mel):

WMS:
curl -I "http://10.11.12.14:8081/geoserver/aodn/wms?service=WMS&version=1.1.0&request=GetMap&layers=aodn:coastal_watch_locations&styles=&ox=138.468,-38.542,153.627,-19.148&width=400&height=51&srs=EPSG:4326&format=application/openlayers"

WFS:
curl -I "http://geoserver-rc.aodn.org.au/geoserver/imos/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=imos:csiro_harvest_phyto_dsdfata&maxFeatures=50&outputFormat=csv"

I also tested hacking the JNDI entry to a bad URL and getting a 500 back at the client.
