### PR TITLE
Http error code

### DIFF
--- a/src/main/java/org/geoserver/ows/DispatcherWithHttpStatus.java
+++ b/src/main/java/org/geoserver/ows/DispatcherWithHttpStatus.java
@@ -1,5 +1,9 @@
 package org.geoserver.ows;
 
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 import javax.servlet.http.HttpServletResponse;
 
 import org.geoserver.platform.Service;
@@ -7,8 +11,17 @@ import org.geoserver.platform.ServiceException;
 
 public class DispatcherWithHttpStatus extends org.geoserver.ows.Dispatcher {
 
+    /**
+     * Logging instance
+     */
+    static Logger logger = org.geotools.util.logging.Logging.getLogger("org.geoserver.ows");
+
     void handleServiceException(ServiceException se, Service service, Request request) {
-        super.handleServiceException(se, service, request);
-        request.getHttpResponse().setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+        try {
+            request.getHttpResponse().sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+        }
+        catch (IOException e) {
+            logger.log(Level.INFO, "Problem sending error", e);
+        }
     }
 }


### PR DESCRIPTION
@danfruehauf I will buy you a beer if this doesn't work!

I tested with:

```
$ curl -w "\n\n%{http_code}\n\n" "http://localhost:8081/geoserver/aodn/wms?service=WMS&version=1.1.0&request=GetMap&layers=aodn:coastal_watch_locationsasdf&styles=&bbox=138.468,-38.542,153.627,-19.148&width=400&height=51&srs=EPSG:4326&format=application/openlayers"
```

(obviously against the non-static geoserver, but anyway, same deal - I hope).
