### PR TITLE
WPS notifier retry

### DIFF
--- a/src/extension/notifier/src/main/resources/applicationContext.xml
+++ b/src/extension/notifier/src/main/resources/applicationContext.xml
@@ -4,6 +4,8 @@
     <bean id="notifierProcess" class="au.org.emii.wps.NotifierProcess">
         <constructor-arg index="0" ref="wpsResourceManager"/>
         <constructor-arg index="1" ref="httpNotifier"/>
+        <constructor-arg index="2" value="3" />
+        <constructor-arg index="3" value="300000" />
     </bean>
     <bean id="httpNotifier" class="au.org.emii.wps.HttpNotifier">
         <constructor-arg index="0" ref="httpClient"/>

--- a/src/extension/notifier/src/test/java/au/org/emii/wps/NotifierProcessTest.java
+++ b/src/extension/notifier/src/test/java/au/org/emii/wps/NotifierProcessTest.java
@@ -20,13 +20,14 @@ public class NotifierProcessTest {
     RawData notifiableData;
     URL callbackUrl;
     String callbackParams;
+    String executionId = "abcd-1234";
 
     URL serverUrl;
 
     @Before
     public void setUp() throws IOException {
         resourceManager = mock(WPSResourceManager.class);
-        when(resourceManager.getExecutionId(true)).thenReturn("abcd-1234");
+        when(resourceManager.getExecutionId(true)).thenReturn(executionId);
 
         httpNotifier = mock(HttpNotifier.class);
 
@@ -47,6 +48,6 @@ public class NotifierProcessTest {
     @Test
     public void testExecuteNotifiesViaCallback() throws IOException {
         process.execute(notifiableData, callbackUrl, callbackParams);
-        verify(httpNotifier).notify(callbackUrl, serverUrl, "abcd-1234", callbackParams);
+        verify(httpNotifier).notify(callbackUrl, serverUrl, executionId, callbackParams);
     }
 }

--- a/src/extension/notifier/src/test/java/au/org/emii/wps/NotifierProcessTest.java
+++ b/src/extension/notifier/src/test/java/au/org/emii/wps/NotifierProcessTest.java
@@ -1,5 +1,6 @@
 package au.org.emii.wps;
 
+import org.geotools.process.ProcessException;
 import org.junit.Before;
 import org.junit.Test;
 import org.geoserver.wps.resource.WPSResourceManager;
@@ -15,6 +16,8 @@ public class NotifierProcessTest {
 
     WPSResourceManager resourceManager;
     HttpNotifier httpNotifier;
+    int retryAttempts = 3;
+    int retryInterval = 0;
     NotifierProcess process;
 
     RawData notifiableData;
@@ -31,7 +34,7 @@ public class NotifierProcessTest {
 
         httpNotifier = mock(HttpNotifier.class);
 
-        process = spy(new NotifierProcess(resourceManager, httpNotifier));
+        process = spy(new NotifierProcess(resourceManager, httpNotifier, retryAttempts, retryInterval));
         serverUrl = new URL("http://wpsserver.com");
         doReturn(serverUrl).when(process).getWpsUrl();
 
@@ -49,5 +52,23 @@ public class NotifierProcessTest {
     public void testExecuteNotifiesViaCallback() throws IOException {
         process.execute(notifiableData, callbackUrl, callbackParams);
         verify(httpNotifier).notify(callbackUrl, serverUrl, executionId, callbackParams);
+    }
+
+    @Test(expected = ProcessException.class)
+    public void testExecuteRetriesFixedNumberOfTimes() throws IOException {
+        doThrow(new IOException()).when(httpNotifier).notify(callbackUrl, serverUrl, executionId, callbackParams);
+
+        process.execute(notifiableData, callbackUrl, callbackParams);
+
+        verify(httpNotifier, times(retryAttempts)).notify(callbackUrl, serverUrl, executionId, callbackParams);
+    }
+
+    @Test
+    public void testExecuteRetriesUntilSuccess() throws IOException {
+        doThrow(new IOException()).doNothing(/* will succeed */).when(httpNotifier).notify(callbackUrl, serverUrl, executionId, callbackParams);
+
+        process.execute(notifiableData, callbackUrl, callbackParams);
+
+        verify(httpNotifier, times(2)).notify(callbackUrl, serverUrl, executionId, callbackParams);
     }
 }


### PR DESCRIPTION
@jkburges thought we might be able to use an Apache library to achieve the same result I'm happy to go down that path and will just leave it up to @jkburges.

Also, I'm thinking that these new parameters should not be passed into the constructor but maybe be passed into the execute method. But this will only be nice if you can configure a default so that they're not required all the time (possibly can be done with the DescribeParameter annotation).