### PR TITLE
WPS notifier with retry

### DIFF
--- a/src/extension/notifier/src/main/java/au/org/emii/wps/HttpNotifier.java
+++ b/src/extension/notifier/src/main/java/au/org/emii/wps/HttpNotifier.java
@@ -1,0 +1,9 @@
+package au.org.emii.wps;
+
+import java.io.IOException;
+import java.net.URL;
+
+public interface HttpNotifier {
+
+    void notify(URL notificationUrl, URL wpsServerUrl, String uuid, String notificationParams) throws IOException;
+}

--- a/src/extension/notifier/src/main/java/au/org/emii/wps/NotifierProcess.java
+++ b/src/extension/notifier/src/main/java/au/org/emii/wps/NotifierProcess.java
@@ -21,9 +21,9 @@ public class NotifierProcess implements GeoServerProcess {
     private static final Logger logger = LoggerFactory.getLogger(NotifierProcess.class);
 
     private final WPSResourceManager resourceManager;
-    private final SimpleHttpNotifier httpNotifier;
+    private final HttpNotifier httpNotifier;
 
-    public NotifierProcess(WPSResourceManager resourceManager, SimpleHttpNotifier httpNotifier) {
+    public NotifierProcess(WPSResourceManager resourceManager, HttpNotifier httpNotifier) {
         this.resourceManager = resourceManager;
         this.httpNotifier = httpNotifier;
     }

--- a/src/extension/notifier/src/main/java/au/org/emii/wps/NotifierProcess.java
+++ b/src/extension/notifier/src/main/java/au/org/emii/wps/NotifierProcess.java
@@ -21,9 +21,9 @@ public class NotifierProcess implements GeoServerProcess {
     private static final Logger logger = LoggerFactory.getLogger(NotifierProcess.class);
 
     private final WPSResourceManager resourceManager;
-    private final HttpNotifier httpNotifier;
+    private final SimpleHttpNotifier httpNotifier;
 
-    public NotifierProcess(WPSResourceManager resourceManager, HttpNotifier httpNotifier) {
+    public NotifierProcess(WPSResourceManager resourceManager, SimpleHttpNotifier httpNotifier) {
         this.resourceManager = resourceManager;
         this.httpNotifier = httpNotifier;
     }

--- a/src/extension/notifier/src/main/java/au/org/emii/wps/RetryingHttpNotifier.java
+++ b/src/extension/notifier/src/main/java/au/org/emii/wps/RetryingHttpNotifier.java
@@ -1,0 +1,54 @@
+package au.org.emii.wps;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URL;
+
+public class RetryingHttpNotifier implements HttpNotifier {
+    private static final Logger logger = LoggerFactory.getLogger(RetryingHttpNotifier.class);
+
+    private final HttpNotifier httpNotifier;
+    private final int maxNotificationAttempts;
+    private final int retryInterval;
+
+    public RetryingHttpNotifier(HttpNotifier httpNotifier, int maxNotificationAttempts, int retryInterval) {
+        this.httpNotifier = httpNotifier;
+        this.maxNotificationAttempts = maxNotificationAttempts;
+        this.retryInterval = retryInterval;
+    }
+
+    public void notify(
+        URL notificationUrl,
+        URL wpsServerUrl,
+        String uuid,
+        String notificationParams) throws IOException
+    {
+        IOException lastException;
+
+        int attempt = 1;
+        do {
+            try {
+                logger.debug("Notification attempt #" + attempt);
+                httpNotifier.notify(notificationUrl, wpsServerUrl, uuid, notificationParams);
+                return;
+            }
+            catch (IOException e) {
+                logger.info("Attempt #" + attempt + " failed", e);
+
+                lastException = e;
+
+                try {
+                    Thread.sleep(retryInterval);
+                }
+                catch (InterruptedException ie) {
+                    logger.debug("Sleep interrupted", ie);
+                }
+            }
+        }
+        while (attempt++ < maxNotificationAttempts);
+
+        throw lastException;
+    }
+}

--- a/src/extension/notifier/src/main/java/au/org/emii/wps/SimpleHttpNotifier.java
+++ b/src/extension/notifier/src/main/java/au/org/emii/wps/SimpleHttpNotifier.java
@@ -5,10 +5,10 @@ import org.geotools.data.ows.HTTPClient;
 import org.apache.http.client.utils.URIBuilder;
 import java.io.IOException;
 
-public class HttpNotifier {
+public class SimpleHttpNotifier {
     private final HTTPClient httpClient;
 
-    public HttpNotifier(HTTPClient httpClient) {
+    public SimpleHttpNotifier(HTTPClient httpClient) {
         this.httpClient = httpClient;
     }
 

--- a/src/extension/notifier/src/main/java/au/org/emii/wps/SimpleHttpNotifier.java
+++ b/src/extension/notifier/src/main/java/au/org/emii/wps/SimpleHttpNotifier.java
@@ -5,7 +5,7 @@ import org.geotools.data.ows.HTTPClient;
 import org.apache.http.client.utils.URIBuilder;
 import java.io.IOException;
 
-public class SimpleHttpNotifier {
+public class SimpleHttpNotifier implements HttpNotifier {
     private final HTTPClient httpClient;
 
     public SimpleHttpNotifier(HTTPClient httpClient) {

--- a/src/extension/notifier/src/main/resources/applicationContext.xml
+++ b/src/extension/notifier/src/main/resources/applicationContext.xml
@@ -3,10 +3,15 @@
 <beans>
     <bean id="notifierProcess" class="au.org.emii.wps.NotifierProcess">
         <constructor-arg index="0" ref="wpsResourceManager"/>
-        <constructor-arg index="1" ref="simpleHttpNotifier"/>
+        <constructor-arg index="1" ref="retryingHttpNotifier"/>
     </bean>
     <bean id="simpleHttpNotifier" class="au.org.emii.wps.SimpleHttpNotifier">
         <constructor-arg index="0" ref="httpClient"/>
+    </bean>
+    <bean id="retryingHttpNotifier" class="au.org.emii.wps.RetryingHttpNotifier">
+        <constructor-arg index="0" ref="simpleHttpNotifier"/>
+        <constructor-arg index="1" value="3" />
+        <constructor-arg index="2" value="300000" />
     </bean>
     <bean id="httpClient" class="org.geotools.data.ows.SimpleHttpClient"/>
 </beans>

--- a/src/extension/notifier/src/main/resources/applicationContext.xml
+++ b/src/extension/notifier/src/main/resources/applicationContext.xml
@@ -3,9 +3,9 @@
 <beans>
     <bean id="notifierProcess" class="au.org.emii.wps.NotifierProcess">
         <constructor-arg index="0" ref="wpsResourceManager"/>
-        <constructor-arg index="1" ref="httpNotifier"/>
+        <constructor-arg index="1" ref="simpleHttpNotifier"/>
     </bean>
-    <bean id="httpNotifier" class="au.org.emii.wps.HttpNotifier">
+    <bean id="simpleHttpNotifier" class="au.org.emii.wps.SimpleHttpNotifier">
         <constructor-arg index="0" ref="httpClient"/>
     </bean>
     <bean id="httpClient" class="org.geotools.data.ows.SimpleHttpClient"/>

--- a/src/extension/notifier/src/test/java/au/org/emii/wps/NotifierProcessTest.java
+++ b/src/extension/notifier/src/test/java/au/org/emii/wps/NotifierProcessTest.java
@@ -14,7 +14,7 @@ import static org.mockito.Mockito.*;
 public class NotifierProcessTest {
 
     WPSResourceManager resourceManager;
-    HttpNotifier httpNotifier;
+    SimpleHttpNotifier httpNotifier;
     NotifierProcess process;
 
     RawData notifiableData;
@@ -28,7 +28,7 @@ public class NotifierProcessTest {
         resourceManager = mock(WPSResourceManager.class);
         when(resourceManager.getExecutionId(true)).thenReturn("abcd-1234");
 
-        httpNotifier = mock(HttpNotifier.class);
+        httpNotifier = mock(SimpleHttpNotifier.class);
 
         process = spy(new NotifierProcess(resourceManager, httpNotifier));
         serverUrl = new URL("http://wpsserver.com");

--- a/src/extension/notifier/src/test/java/au/org/emii/wps/RetryingHttpNotifierTest.java
+++ b/src/extension/notifier/src/test/java/au/org/emii/wps/RetryingHttpNotifierTest.java
@@ -1,0 +1,49 @@
+package au.org.emii.wps;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.URL;
+
+import static org.mockito.Mockito.*;
+
+public class RetryingHttpNotifierTest {
+
+    HttpNotifier wrappedNotifier;
+    RetryingHttpNotifier retryingNotifier;
+    int notificationAttempts = 3;
+    int retryInterval = 0;
+
+    URL notificationUrl;
+    URL wpsServerUrl;
+    String uuid = "uuid";
+    String notificationParams = "notificationParams";
+
+    @Before
+    public void setUp() throws IOException {
+        notificationUrl = new URL("http://notificationurl.com");
+        wpsServerUrl = new URL("http://wpsServer.com");
+
+        wrappedNotifier = mock(SimpleHttpNotifier.class);
+        retryingNotifier = new RetryingHttpNotifier(wrappedNotifier, notificationAttempts, retryInterval);
+    }
+
+    @Test(expected = IOException.class)
+    public void testExecuteRetriesFixedNumberOfTimes() throws IOException {
+        doThrow(new IOException()).when(wrappedNotifier).notify(notificationUrl, wpsServerUrl, uuid, notificationParams);
+
+        retryingNotifier.notify(notificationUrl, wpsServerUrl, uuid, notificationParams);
+
+        verify(wrappedNotifier, times(notificationAttempts)).notify(notificationUrl, wpsServerUrl, uuid, notificationParams);
+    }
+
+    @Test
+    public void testExecuteRetriesUntilSuccess() throws IOException {
+        doThrow(new IOException()).doNothing(/* will succeed */).when(wrappedNotifier).notify(notificationUrl, wpsServerUrl, uuid, notificationParams);
+
+        retryingNotifier.notify(notificationUrl, wpsServerUrl, uuid, notificationParams);
+
+        verify(wrappedNotifier, times(2)).notify(notificationUrl, wpsServerUrl, uuid, notificationParams);
+    }
+}

--- a/src/extension/notifier/src/test/java/au/org/emii/wps/SimpleHttpNotifierTest.java
+++ b/src/extension/notifier/src/test/java/au/org/emii/wps/SimpleHttpNotifierTest.java
@@ -9,12 +9,12 @@ import org.geotools.data.ows.HTTPClient;
 
 import static org.mockito.Mockito.*;
 
-public class HttpNotifierTest {
+public class SimpleHttpNotifierTest {
 
     @Test
     public void testNotifyMakeHttpRequest() throws IOException {
         HTTPClient httpClient = mock(SimpleHttpClient.class);
-        HttpNotifier notifier = new HttpNotifier(httpClient);
+        SimpleHttpNotifier notifier = new SimpleHttpNotifier(httpClient);
 
         URL notificationUrl = new URL("http://notifiee");
         URL wpsServiceUrl = new URL("http://notifier");


### PR DESCRIPTION
This is an implementation of HTTP notification with retry functionality.

There is a new interface `HttpNotifier` which can be made more general (i.e. `Notifier`) later, as needed.

I had a think about how `maxNotificationAttempts` and `retryInterval` are injected and I think I'm okay with them being in the constructor like this. I don't think they should be properties with mutator methods (some good points were made about this issue in [this blog comment](http://blog.schauderhaft.de/2012/01/01/the-one-correct-way-to-do-dependency-injection/comment-page-1/#comment-4765)).