### PR TITLE
Regex restriction for uniqueValues

### DIFF
--- a/src/extension/layer-filters/src/main/resources/applicationContext.xml
+++ b/src/extension/layer-filters/src/main/resources/applicationContext.xml
@@ -20,6 +20,13 @@
 
     <bean id="layerFiltersService" class="au.org.emii.geoserver.extensions.filters.LayerFiltersService">
         <property name="catalog" ref="catalog"/>
+
+        <property name="uniqueValuesAllowedRegex">
+            <list>
+                <!-- Allow unique values on _map layers -->
+                <value>.*:.*_map/.*</value>
+            </list>
+        </property>
     </bean>
 
     <!-- This creates a Service descriptor, which allows the org.geoserver.ows.Dispatcher


### PR DESCRIPTION
Allow restricting uniqueValues with a regex. By default allow only
layers with a _map suffix.