### PR TITLE
Add MS SQL Server support via jtds

### DIFF
--- a/src/main/pom.xml
+++ b/src/main/pom.xml
@@ -65,6 +65,16 @@
             <version>${geoserver.version}</version>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>net.sourceforge.jtds</groupId>
+            <artifactId>jtds</artifactId>
+            <version>1.3.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.geotools.jdbc</groupId>
+            <artifactId>gt-jdbc-sqlserver</artifactId>
+            <version>12.1</version>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Geoserver can support SQL Server via the gt-jdbc-sqlserver plugin, but it also needs a JDBC driver. The two options are Microsoft's own driver, free to download but not redistributable, or jTDS (http://jtds.sourceforge.net/) which is LGPL'd.  This uses jtds.