### PR TITLE
enable jetty:run on main project

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,18 +10,18 @@ Configures a GeoServer war file with the following;
 To build:
 
 ```
-git submodule update --init
-mvn clean install -U -Dmaven.test.skip=true 
+mvn clean install -U 
 ```
 
-To update the submodule(s), e.g.:
+To run:
 
 ```
-cd src/extension/geoserver-layer-filter-extension/
-git pull origin master 
-cd -
-git status
-git add src/extension/geoserver-layer-filter-extension
-git commit -m "update filter plugin extension"
-git push origin master
+cd src/main
+mvn jetty:run
+```
+
+GeoServer will then be available at:
+
+```
+http://localhost:8080
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -80,8 +80,8 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.1</version>
                     <configuration>
-                        <source>1.5</source>
-                        <target>1.5</target>
+                        <source>1.7</source>
+                        <target>1.7</target>
                     </configuration>
                 </plugin>
             </plugins>
@@ -102,6 +102,10 @@
             <id>unidata-releases</id>
             <name>UNIDATA Releases</name>
             <url>https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases/</url>
+        </repository>
+        <repository>
+            <id>mvnrepository</id>
+            <url>http://mvnrepository.com/artifact/</url>
         </repository>
     </repositories>
 

--- a/src/main/pom.xml
+++ b/src/main/pom.xml
@@ -101,7 +101,15 @@
                     <warName>geoserver-${project.version}-imos</warName>
                 </configuration>
             </plugin>
-        </plugins>
+            <plugin>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-maven-plugin</artifactId>
+                <version>9.2.11.v20150529</version>
+                <configuration>
+                    <scanIntervalSeconds>2</scanIntervalSeconds>
+                </configuration>
+            </plugin>
+       </plugins>
 
     </build>
 


### PR DESCRIPTION
Any reason why we need to wait for this?  I can use it now.