### PR TITLE
Modify notifier to return response from wrapped process

### DIFF
--- a/src/extension/wps/doc/wps-notifier.xml
+++ b/src/extension/wps/doc/wps-notifier.xml
@@ -3,30 +3,32 @@
     <ows:Identifier>gs:Notifier</ows:Identifier>
     <wps:DataInputs>
         <wps:Input>
-            <ows:Identifier>notifiable</ows:Identifier>
-            <wps:Reference mimeType="application/octet-stream" xlink:href="http://geoserver/wps" method="POST">
+            <ows:Identifier>wrappedProcessResponse</ows:Identifier>
+            <wps:Reference mimeType="application/xml" xlink:href="http://geoserver/wps" method="POST">
                 <wps:Body>
-                    <wps:Execute version="1.0.0" service="WPS">
+                    <wps:Execute version="1.0.0" service="WPS" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.opengis.net/wps/1.0.0" xmlns:wfs="http://www.opengis.net/wfs" xmlns:wps="http://www.opengis.net/wps/1.0.0" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:gml="http://www.opengis.net/gml" xmlns:ogc="http://www.opengis.net/ogc" xmlns:wcs="http://www.opengis.net/wcs/1.1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xsi:schemaLocation="http://www.opengis.net/wps/1.0.0 http://schemas.opengis.net/wps/1.0.0/wpsAll.xsd">
                         <ows:Identifier>gs:NetcdfOutput</ows:Identifier>
                         <wps:DataInputs>
                             <wps:Input>
                                 <ows:Identifier>typeName</ows:Identifier>
                                 <wps:Data>
-                                    <wps:LiteralData>imos:anmn_ts_timeseries_data</wps:LiteralData>
+                                    <wps:LiteralData>imos:ts_timeseries</wps:LiteralData>
                                 </wps:Data>
                             </wps:Input>
                             <wps:Input>
                                 <ows:Identifier>cqlFilter</ows:Identifier>
                                 <wps:Data>
-                                    <wps:LiteralData>INTERSECTS(geom,POLYGON((113.33 -34.09,113.33 -30.98,131.11 -30.98,131.11 -34.09,113.33 -34.09))) AND TIME &gt;= '2009-01-13T23:00:00Z' AND TIME &lt;= '2009-01-14T00:00:00Z'</wps:LiteralData>
+                                    <wps:LiteralData>BBOX(geom, 115.32, -32.03, 115.47, -31.93)</wps:LiteralData>
                                 </wps:Data>
                             </wps:Input>
                         </wps:DataInputs>
                         <wps:ResponseForm>
-                            <wps:ResponseDocument storeExecuteResponse="true"
-                                                  lineage="false" status="true">
+                            <wps:ResponseDocument storeExecuteResponse="false" status="true">
                                 <wps:Output asReference="true" mimeType="application/zip">
                                     <ows:Identifier>result</ows:Identifier>
+                                </wps:Output>
+                                <wps:Output asReference="true" mimeType="text/plain">
+                                    <ows:Identifier>errors</ows:Identifier>
                                 </wps:Output>
                             </wps:ResponseDocument>
                         </wps:ResponseForm>
@@ -49,8 +51,8 @@
     </wps:DataInputs>
     <wps:ResponseForm>
         <wps:ResponseDocument storeExecuteResponse="true"
-                              lineage="false" status="true">
-            <wps:Output asReference="true" mimeType="application/zip">
+            lineage="false" status="true">
+            <wps:Output asReference="true" mimeType="application/xml">
                 <ows:Identifier>result</ows:Identifier>
             </wps:Output>
         </wps:ResponseDocument>

--- a/src/extension/wps/src/main/java/au/org/emii/wps/NotifierProcess.java
+++ b/src/extension/wps/src/main/java/au/org/emii/wps/NotifierProcess.java
@@ -32,10 +32,10 @@ public class NotifierProcess implements GeoServerProcess {
         this.httpNotifier = httpNotifier;
     }
 
-    @DescribeResult(name="result", description="NetCDF file", meta={"mimeTypes=application/x-netcdf"})
+    @DescribeResult(name="result", description="Wrapped process response", meta={"mimeTypes=application/xml"})
     public RawData execute(
-        @DescribeParameter(name="notifiable", description="NetCDF file")
-        RawData notifiableData,
+        @DescribeParameter(name="wrappedProcessResponse", description="Wrapped process response")
+        RawData response,
         @DescribeParameter(name="callbackUrl", description="Callback URL")
         URL callbackUrl,
         @DescribeParameter(name="callbackParams", description="Parameters to append to the callback")
@@ -44,7 +44,7 @@ public class NotifierProcess implements GeoServerProcess {
 
         try {
             httpNotifier.notify(callbackUrl, getWpsUrl(), getId(), callbackParams);
-            return notifiableData;
+            return response;
         }
         catch (IOException e) {
             logger.error("Error sending notification", e);

--- a/src/extension/wps/src/test/java/au/org/emii/wps/NotifierProcessTest.java
+++ b/src/extension/wps/src/test/java/au/org/emii/wps/NotifierProcessTest.java
@@ -1,17 +1,21 @@
 package au.org.emii.wps;
 
-import au.org.emii.notifier.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import java.io.IOException;
+import java.net.URL;
+
+import org.geoserver.wps.process.StringRawData;
+import org.geoserver.wps.resource.WPSResourceManager;
 import org.junit.Before;
 import org.junit.Test;
-import org.geoserver.wps.resource.WPSResourceManager;
-import org.geoserver.wps.process.RawData;
 
-import java.net.URL;
-import java.io.IOException;
-
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import au.org.emii.notifier.SimpleHttpNotifier;
 
 public class NotifierProcessTest {
 
@@ -19,7 +23,7 @@ public class NotifierProcessTest {
     SimpleHttpNotifier httpNotifier;
     NotifierProcess process;
 
-    RawData notifiableData;
+    StringRawData wrappedProcessResponse;
     URL callbackUrl;
     String callbackParams;
 
@@ -36,19 +40,19 @@ public class NotifierProcessTest {
         serverUrl = new URL("http://wpsserver.com");
         doReturn(serverUrl).when(process).getWpsUrl();
 
-        notifiableData = mock(RawData.class);
+        wrappedProcessResponse = mock(StringRawData.class);
         callbackUrl = new URL("http://example.com");
         callbackParams = "email.to=bob@example.com";
     }
 
     @Test
     public void testExecuteReturnsGivenData() throws IOException {
-        assertEquals(notifiableData, process.execute(notifiableData, callbackUrl, callbackParams));
+        assertEquals(wrappedProcessResponse, process.execute(wrappedProcessResponse, callbackUrl, callbackParams));
     }
 
     @Test
     public void testExecuteNotifiesViaCallback() throws IOException {
-        process.execute(notifiableData, callbackUrl, callbackParams);
+        process.execute(wrappedProcessResponse, callbackUrl, callbackParams);
         verify(httpNotifier).notify(callbackUrl, serverUrl, "abcd-1234", callbackParams);
     }
 }

--- a/src/extension/wps/src/test/java/au/org/emii/wps/NotifierProcessTest.java
+++ b/src/extension/wps/src/test/java/au/org/emii/wps/NotifierProcessTest.java
@@ -10,7 +10,7 @@ import static org.mockito.Mockito.when;
 import java.io.IOException;
 import java.net.URL;
 
-import org.geoserver.wps.process.StringRawData;
+import org.geoserver.wps.process.RawData;
 import org.geoserver.wps.resource.WPSResourceManager;
 import org.junit.Before;
 import org.junit.Test;
@@ -23,7 +23,7 @@ public class NotifierProcessTest {
     SimpleHttpNotifier httpNotifier;
     NotifierProcess process;
 
-    StringRawData wrappedProcessResponse;
+    RawData wrappedProcessResponse;
     URL callbackUrl;
     String callbackParams;
 
@@ -40,7 +40,7 @@ public class NotifierProcessTest {
         serverUrl = new URL("http://wpsserver.com");
         doReturn(serverUrl).when(process).getWpsUrl();
 
-        wrappedProcessResponse = mock(StringRawData.class);
+        wrappedProcessResponse = mock(RawData.class);
         callbackUrl = new URL("http://example.com");
         callbackParams = "email.to=bob@example.com";
     }


### PR DESCRIPTION
Notifier now returns in its response the response returned by the wrapped process.  The wrapped process' response can be included in the notifier's response document or stored separately.

Not sure whether this is any better than the other options tried/suggested!   This option puts errors into a different output to sub-setted files and just returns the wrapped process response rather than copying the netcdf files via http. 