### PR TITLE
Modify notifier to return response from wrapped process

### DIFF
--- a/src/extension/wps/doc/response-notifier.xml
+++ b/src/extension/wps/doc/response-notifier.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wps:ExecuteResponse xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:wps="http://www.opengis.net/wps/1.0.0" xmlns:xlink="http://www.w3.org/1999/xlink" xml:lang="en" service="WPS" serviceInstance="http://localhost:8080/ows?" statusLocation="http://localhost:8080/ows?service=WPS&amp;version=1.0.0&amp;request=GetExecutionStatus&amp;executionId=5d9c9b2d-eeee-4900-b496-9ff9aa401daf" version="1.0.0">
+  <wps:Process wps:processVersion="1.0.0">
+    <ows:Identifier>gs:Notifier</ows:Identifier>
+    <ows:Title>Notifier</ows:Title>
+    <ows:Abstract>Notify subscribers when a WPS process completes</ows:Abstract>
+  </wps:Process>
+  <wps:Status creationTime="2015-11-13T00:17:40.364Z">
+    <wps:ProcessSucceeded>Process succeeded.</wps:ProcessSucceeded>
+  </wps:Status>
+  <wps:ProcessOutputs>
+    <wps:Output>
+      <ows:Identifier>result</ows:Identifier>
+      <ows:Title>Wrapped process response</ows:Title>
+      <wps:Data>
+        <wps:ComplexData mimeType="text/xml">
+          <wps:ExecuteResponse xml:lang="en" service="WPS" serviceInstance="http://localhost:8080/ows?" version="1.0.0">
+            <wps:Process wps:processVersion="1.0.0">
+              <ows:Identifier>gs:NetcdfOutput</ows:Identifier>
+              <ows:Title>NetCDF download</ows:Title>
+              <ows:Abstract>Subset and download collection as NetCDF files</ows:Abstract>
+            </wps:Process>
+            <wps:Status creationTime="2015-11-13T00:17:40.418Z">
+              <wps:ProcessSucceeded>Process succeeded.</wps:ProcessSucceeded>
+            </wps:Status>
+            <wps:ProcessOutputs>
+              <wps:Output>
+                <ows:Identifier>result</ows:Identifier>
+                <ows:Title>Zipped netcdf files</ows:Title>
+                <wps:Reference href="http://localhost:8080/ows?service=WPS&amp;version=1.0.0&amp;request=GetExecutionResult&amp;executionId=dbe1671e-0f01-40db-852b-c5e9b9aeebf4&amp;outputId=result.zip&amp;mimetype=application%2Fzip" mimeType="application/zip"/>
+              </wps:Output>
+              <wps:Output>
+                <ows:Identifier>errors</ows:Identifier>
+                <ows:Title>Errors returned trying to perform subset</ows:Title>
+                <wps:Data>
+                  <wps:LiteralData/>
+                </wps:Data>
+              </wps:Output>
+            </wps:ProcessOutputs>
+          </wps:ExecuteResponse>
+        </wps:ComplexData>
+      </wps:Data>
+    </wps:Output>
+  </wps:ProcessOutputs>
+</wps:ExecuteResponse>

--- a/src/extension/wps/doc/wps-notifier.xml
+++ b/src/extension/wps/doc/wps-notifier.xml
@@ -3,34 +3,38 @@
     <ows:Identifier>gs:Notifier</ows:Identifier>
     <wps:DataInputs>
         <wps:Input>
-            <ows:Identifier>notifiable</ows:Identifier>
-            <wps:Reference mimeType="application/octet-stream" xlink:href="http://geoserver/wps" method="POST">
+            <ows:Identifier>wrappedProcessResponse</ows:Identifier>
+            <wps:Reference mimeType="text/xml" xlink:href="http://localhost:8080/wps" method="POST">
                 <wps:Body>
-                    <wps:Execute version="1.0.0" service="WPS">
+                    <![CDATA[
+                    <wps:Execute version="1.0.0" service="WPS" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.opengis.net/wps/1.0.0" xmlns:wfs="http://www.opengis.net/wfs" xmlns:wps="http://www.opengis.net/wps/1.0.0" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:gml="http://www.opengis.net/gml" xmlns:ogc="http://www.opengis.net/ogc" xmlns:wcs="http://www.opengis.net/wcs/1.1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xsi:schemaLocation="http://www.opengis.net/wps/1.0.0 http://schemas.opengis.net/wps/1.0.0/wpsAll.xsd">
                         <ows:Identifier>gs:NetcdfOutput</ows:Identifier>
                         <wps:DataInputs>
                             <wps:Input>
                                 <ows:Identifier>typeName</ows:Identifier>
                                 <wps:Data>
-                                    <wps:LiteralData>imos:anmn_ts_timeseries_data</wps:LiteralData>
+                                    <wps:LiteralData>imos:ts_timeseries</wps:LiteralData>
                                 </wps:Data>
                             </wps:Input>
                             <wps:Input>
                                 <ows:Identifier>cqlFilter</ows:Identifier>
                                 <wps:Data>
-                                    <wps:LiteralData>INTERSECTS(geom,POLYGON((113.33 -34.09,113.33 -30.98,131.11 -30.98,131.11 -34.09,113.33 -34.09))) AND TIME &gt;= '2009-01-13T23:00:00Z' AND TIME &lt;= '2009-01-14T00:00:00Z'</wps:LiteralData>
+                                    <wps:LiteralData>BBOX(geom, 115.32, -32.03, 115.47, -31.93)</wps:LiteralData>
                                 </wps:Data>
                             </wps:Input>
                         </wps:DataInputs>
                         <wps:ResponseForm>
-                            <wps:ResponseDocument storeExecuteResponse="true"
-                                                  lineage="false" status="true">
+                            <wps:ResponseDocument>
                                 <wps:Output asReference="true" mimeType="application/zip">
                                     <ows:Identifier>result</ows:Identifier>
+                                </wps:Output>
+                                <wps:Output>
+                                    <ows:Identifier>errors</ows:Identifier>
                                 </wps:Output>
                             </wps:ResponseDocument>
                         </wps:ResponseForm>
                     </wps:Execute>
+                    ]]>
                 </wps:Body>
             </wps:Reference>
         </wps:Input>
@@ -49,8 +53,8 @@
     </wps:DataInputs>
     <wps:ResponseForm>
         <wps:ResponseDocument storeExecuteResponse="true"
-                              lineage="false" status="true">
-            <wps:Output asReference="true" mimeType="application/zip">
+            lineage="false" status="true">
+            <wps:Output>
                 <ows:Identifier>result</ows:Identifier>
             </wps:Output>
         </wps:ResponseDocument>

--- a/src/extension/wps/src/main/java/au/org/emii/wps/NotifierProcess.java
+++ b/src/extension/wps/src/main/java/au/org/emii/wps/NotifierProcess.java
@@ -9,7 +9,7 @@ import net.opengis.wps10.ExecuteType;
 import org.geoserver.ows.Dispatcher;
 import org.geoserver.platform.Operation;
 import org.geoserver.wps.gs.GeoServerProcess;
-import org.geoserver.wps.process.RawData;
+import org.geoserver.wps.process.StringRawData;
 import org.geoserver.wps.resource.WPSResourceManager;
 import org.geotools.process.ProcessException;
 import org.geotools.process.factory.DescribeParameter;
@@ -32,10 +32,10 @@ public class NotifierProcess implements GeoServerProcess {
         this.httpNotifier = httpNotifier;
     }
 
-    @DescribeResult(name="result", description="NetCDF file", meta={"mimeTypes=application/x-netcdf"})
-    public RawData execute(
-        @DescribeParameter(name="notifiable", description="NetCDF file")
-        RawData notifiableData,
+    @DescribeResult(name="result", description="Wrapped process response", meta={"mimeTypes=application/xml"})
+    public StringRawData execute(
+        @DescribeParameter(name="wrappedProcessResponse", description="Wrapped process response")
+        StringRawData response,
         @DescribeParameter(name="callbackUrl", description="Callback URL")
         URL callbackUrl,
         @DescribeParameter(name="callbackParams", description="Parameters to append to the callback")
@@ -44,7 +44,7 @@ public class NotifierProcess implements GeoServerProcess {
 
         try {
             httpNotifier.notify(callbackUrl, getWpsUrl(), getId(), callbackParams);
-            return notifiableData;
+            return response;
         }
         catch (IOException e) {
             logger.error("Error sending notification", e);

--- a/src/extension/wps/src/main/java/au/org/emii/wps/StringRawDataXmlPPIO.java
+++ b/src/extension/wps/src/main/java/au/org/emii/wps/StringRawDataXmlPPIO.java
@@ -1,0 +1,44 @@
+package au.org.emii.wps;
+
+import java.io.InputStream;
+import java.io.StringReader;
+
+import javax.xml.namespace.QName;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
+
+import org.apache.commons.io.IOUtils;
+import org.geoserver.wps.ppio.XMLPPIO;
+import org.geoserver.wps.process.StringRawData;
+import org.xml.sax.ContentHandler;
+import org.xml.sax.InputSource;
+import org.xml.sax.XMLReader;
+
+/**
+ * Decoder/encoder for 'text/xml' StringRawData
+ *  
+ */
+
+public class StringRawDataXmlPPIO extends XMLPPIO {
+
+    public StringRawDataXmlPPIO() {
+        super(StringRawData.class, StringRawData.class, new QName("notUsed"));
+   }
+
+    @Override
+    public Object decode(InputStream input) throws Exception {
+        return new StringRawData(IOUtils.toString(input, null), mimeType);
+    }
+
+    @Override
+    public void encode(Object object, ContentHandler handler) throws Exception {
+        String xmlString = ((StringRawData) object).getData();
+        SAXParserFactory spf = SAXParserFactory.newInstance();
+        spf.setNamespaceAware(true);
+        SAXParser saxParser = spf.newSAXParser();
+        XMLReader xmlReader = saxParser.getXMLReader();
+        xmlReader.setContentHandler(handler);
+        xmlReader.parse(new InputSource(new StringReader(xmlString)));
+    }
+
+}

--- a/src/extension/wps/src/main/resources/applicationContext.xml
+++ b/src/extension/wps/src/main/resources/applicationContext.xml
@@ -35,4 +35,6 @@
       <constructor-arg index="1" ref="catalog"/>
       <constructor-arg index="2" ref="servletContext"/>
     </bean>
-</beans>
+
+    <bean id="xmlRawDataPPIO" class="au.org.emii.wps.StringRawDataXmlPPIO"/>
+ </beans>

--- a/src/extension/wps/src/test/java/au/org/emii/wps/NotifierProcessTest.java
+++ b/src/extension/wps/src/test/java/au/org/emii/wps/NotifierProcessTest.java
@@ -1,17 +1,21 @@
 package au.org.emii.wps;
 
-import au.org.emii.notifier.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import java.io.IOException;
+import java.net.URL;
+
+import org.geoserver.wps.process.StringRawData;
+import org.geoserver.wps.resource.WPSResourceManager;
 import org.junit.Before;
 import org.junit.Test;
-import org.geoserver.wps.resource.WPSResourceManager;
-import org.geoserver.wps.process.RawData;
 
-import java.net.URL;
-import java.io.IOException;
-
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import au.org.emii.notifier.SimpleHttpNotifier;
 
 public class NotifierProcessTest {
 
@@ -19,7 +23,7 @@ public class NotifierProcessTest {
     SimpleHttpNotifier httpNotifier;
     NotifierProcess process;
 
-    RawData notifiableData;
+    StringRawData wrappedProcessResponse;
     URL callbackUrl;
     String callbackParams;
 
@@ -36,19 +40,19 @@ public class NotifierProcessTest {
         serverUrl = new URL("http://wpsserver.com");
         doReturn(serverUrl).when(process).getWpsUrl();
 
-        notifiableData = mock(RawData.class);
+        wrappedProcessResponse = mock(StringRawData.class);
         callbackUrl = new URL("http://example.com");
         callbackParams = "email.to=bob@example.com";
     }
 
     @Test
     public void testExecuteReturnsGivenData() throws IOException {
-        assertEquals(notifiableData, process.execute(notifiableData, callbackUrl, callbackParams));
+        assertEquals(wrappedProcessResponse, process.execute(wrappedProcessResponse, callbackUrl, callbackParams));
     }
 
     @Test
     public void testExecuteNotifiesViaCallback() throws IOException {
-        process.execute(notifiableData, callbackUrl, callbackParams);
+        process.execute(wrappedProcessResponse, callbackUrl, callbackParams);
         verify(httpNotifier).notify(callbackUrl, serverUrl, "abcd-1234", callbackParams);
     }
 }


### PR DESCRIPTION
Modified notifier process to return the response from the wrapped wps process so that the downloadable file or errors creating it are both accessible.

For example submitting: https://github.com/aodn/geoserver-build/blob/return-response/src/extension/wps/doc/wps-notifier.xml
Returns: https://github.com/aodn/geoserver-build/blob/return-response/src/extension/wps/doc/response-notifier.xml

Struggled with GeoServers WPS implementation somewhat:

a) using http://geoserver/wps in a reference href results in geoserver directly passing only one output from the called process to the calling process.  Useful for not streaming data via http but useless when trying to return two outputs
b) can't use RawData when using references  when not using http://geoserver/wps as the input stream is closed and so must use an output which stores the input (I used StringRawData)
c) had to work out  how to write my own support for encoding XML string data into the response

