### PR TITLE
Include whether subset succeeded or failed in portal callback

### DIFF
--- a/src/extension/wps/src/main/java/au/org/emii/notifier/HttpNotifier.java
+++ b/src/extension/wps/src/main/java/au/org/emii/notifier/HttpNotifier.java
@@ -5,5 +5,5 @@ import java.net.URL;
 
 public interface HttpNotifier {
 
-    void notify(URL notificationUrl, URL wpsServerUrl, String uuid, String notificationParams) throws IOException;
+    void notify(URL notificationUrl, URL wpsServerUrl, String uuid, boolean successful, String notificationParams) throws IOException;
 }

--- a/src/extension/wps/src/main/java/au/org/emii/notifier/RetryingHttpNotifier.java
+++ b/src/extension/wps/src/main/java/au/org/emii/notifier/RetryingHttpNotifier.java
@@ -23,6 +23,7 @@ public class RetryingHttpNotifier implements HttpNotifier {
         URL notificationUrl,
         URL wpsServerUrl,
         String uuid,
+        boolean successful,
         String notificationParams) throws IOException
     {
         IOException lastException;
@@ -31,7 +32,7 @@ public class RetryingHttpNotifier implements HttpNotifier {
         do {
             try {
                 logger.debug("Notification attempt #" + attempt);
-                httpNotifier.notify(notificationUrl, wpsServerUrl, uuid, notificationParams);
+                httpNotifier.notify(notificationUrl, wpsServerUrl, uuid, successful, notificationParams);
                 return;
             }
             catch (IOException e) {

--- a/src/extension/wps/src/main/java/au/org/emii/notifier/SimpleHttpNotifier.java
+++ b/src/extension/wps/src/main/java/au/org/emii/notifier/SimpleHttpNotifier.java
@@ -16,12 +16,14 @@ public class SimpleHttpNotifier implements HttpNotifier {
         URL notificationUrl,
         URL wpsServerUrl,
         String uuid,
+        boolean successful,
         String notificationParams
     ) throws IOException {
         try {
             URIBuilder builder = new URIBuilder(notificationUrl.toURI());
             builder.setParameter("server", wpsServerUrl.toExternalForm());
             builder.setParameter("uuid", uuid);
+            builder.setParameter("successful", Boolean.toString(successful));
 
             String callbackUrlAsString = builder.build().toURL().toExternalForm();
             callbackUrlAsString += "&" + notificationParams;

--- a/src/extension/wps/src/main/java/au/org/emii/wps/AbstractNotifierProcess.java
+++ b/src/extension/wps/src/main/java/au/org/emii/wps/AbstractNotifierProcess.java
@@ -25,11 +25,21 @@ public abstract class AbstractNotifierProcess implements GeoServerProcess {
         this.httpNotifier = httpNotifier;
     }
 
-    protected void notify(URL callbackUrl, String callbackParams) {
+    protected void notifySuccess(URL callbackUrl, String callbackParams) {
+        boolean successful = true;
+        notify(successful, callbackUrl, callbackParams);
+    }
+
+    protected void notifyFailure(URL callbackUrl, String callbackParams) {
+        boolean successful = false;
+        notify(successful, callbackUrl, callbackParams);
+    }
+
+    protected void notify(boolean successful, URL callbackUrl, String callbackParams) {
         if (callbackUrl == null) return;
 
         try {
-            httpNotifier.notify(callbackUrl, getWpsUrl(), getId(), callbackParams);
+            httpNotifier.notify(callbackUrl, getWpsUrl(), getId(), successful, callbackParams);
         } catch (IOException ioe) {
             logger.error("Could not call callback", ioe);
         }

--- a/src/extension/wps/src/main/java/au/org/emii/wps/GoGoDuckProcess.java
+++ b/src/extension/wps/src/main/java/au/org/emii/wps/GoGoDuckProcess.java
@@ -85,12 +85,12 @@ public class GoGoDuckProcess extends AbstractNotifierProcess {
             ggd.setProgressListener(progressListener);
 
             ggd.run();
+            notifySuccess(callbackUrl, callbackParams);
             return new FileRawData(outputFile, "application/x-netcdf", "nc");
         } catch (GoGoDuckException e) {
             logger.error(e.toString());
+            notifyFailure(callbackUrl, callbackParams);
             throw new ProcessException(e);
-        } finally {
-            notify(callbackUrl, callbackParams);
         }
     }
 

--- a/src/extension/wps/src/main/java/au/org/emii/wps/NetcdfOutputProcess.java
+++ b/src/extension/wps/src/main/java/au/org/emii/wps/NetcdfOutputProcess.java
@@ -134,6 +134,8 @@ public class NetcdfOutputProcess extends AbstractNotifierProcess {
                 }
             }
 
+            notifySuccess(callbackUrl, callbackParams);
+
             return new FileRawData(outputFile, "application/zip");
 
         } catch (Exception e) {
@@ -151,12 +153,11 @@ public class NetcdfOutputProcess extends AbstractNotifierProcess {
                     logger.info("problem closing connection");
                 }
             }
+            notifyFailure(callbackUrl, callbackParams);
             throw new ProcessException(e.getMessage());
         } finally {
             IOUtils.closeQuietly(config);
             IOUtils.closeQuietly(os);
-
-            notify(callbackUrl, callbackParams);
         }
     }
 

--- a/src/extension/wps/src/test/java/au/org/emii/notifier/RetryingHttpNotifierTest.java
+++ b/src/extension/wps/src/test/java/au/org/emii/notifier/RetryingHttpNotifierTest.java
@@ -19,6 +19,7 @@ public class RetryingHttpNotifierTest {
     URL wpsServerUrl;
     String uuid = "uuid";
     String notificationParams = "notificationParams";
+    boolean successful = true;
 
     @Before
     public void setUp() throws IOException {
@@ -31,19 +32,19 @@ public class RetryingHttpNotifierTest {
 
     @Test(expected = IOException.class)
     public void testExecuteRetriesFixedNumberOfTimes() throws IOException {
-        doThrow(new IOException()).when(wrappedNotifier).notify(notificationUrl, wpsServerUrl, uuid, notificationParams);
+        doThrow(new IOException()).when(wrappedNotifier).notify(notificationUrl, wpsServerUrl, uuid, successful, notificationParams);
 
-        retryingNotifier.notify(notificationUrl, wpsServerUrl, uuid, notificationParams);
+        retryingNotifier.notify(notificationUrl, wpsServerUrl, uuid, successful, notificationParams);
 
-        verify(wrappedNotifier, times(notificationAttempts)).notify(notificationUrl, wpsServerUrl, uuid, notificationParams);
+        verify(wrappedNotifier, times(notificationAttempts)).notify(notificationUrl, wpsServerUrl, uuid, successful, notificationParams);
     }
 
     @Test
     public void testExecuteRetriesUntilSuccess() throws IOException {
-        doThrow(new IOException()).doNothing(/* will succeed */).when(wrappedNotifier).notify(notificationUrl, wpsServerUrl, uuid, notificationParams);
+        doThrow(new IOException()).doNothing(/* will succeed */).when(wrappedNotifier).notify(notificationUrl, wpsServerUrl, uuid, successful, notificationParams);
 
-        retryingNotifier.notify(notificationUrl, wpsServerUrl, uuid, notificationParams);
+        retryingNotifier.notify(notificationUrl, wpsServerUrl, uuid, successful, notificationParams);
 
-        verify(wrappedNotifier, times(2)).notify(notificationUrl, wpsServerUrl, uuid, notificationParams);
+        verify(wrappedNotifier, times(2)).notify(notificationUrl, wpsServerUrl, uuid, successful, notificationParams);
     }
 }

--- a/src/extension/wps/src/test/java/au/org/emii/notifier/SimpleHttpNotifierTest.java
+++ b/src/extension/wps/src/test/java/au/org/emii/notifier/SimpleHttpNotifierTest.java
@@ -19,12 +19,13 @@ public class SimpleHttpNotifierTest {
         URL notificationUrl = new URL("http://notifiee");
         URL wpsServiceUrl = new URL("http://notifier");
         String id = "1234";
+        boolean successful = true;
 
         String notificationParams = "foo=bar";
 
-        notifier.notify(notificationUrl, wpsServiceUrl, id, notificationParams);
+        notifier.notify(notificationUrl, wpsServiceUrl, id, successful, notificationParams);
 
-        URL expectedUrl = new URL("http://notifiee?server=http%3A%2F%2Fnotifier&uuid=1234&foo=bar");
+        URL expectedUrl = new URL("http://notifiee?server=http%3A%2F%2Fnotifier&uuid=1234&successful=true&foo=bar");
         verify(httpClient).get(expectedUrl);
     }
 }


### PR DESCRIPTION
Allow portal to send correct email by including whether the subset succeeded or failed in the callback