### PR TITLE
Remove geowebcache plugin which is included by default in core geoserver

### DIFF
--- a/src/main/pom.xml
+++ b/src/main/pom.xml
@@ -100,6 +100,8 @@
                             <artifactId>gs-web-app</artifactId>
                                 <excludes>
                                     <exclude>WEB-INF/lib/postgresql*jdbc*.jar</exclude>
+                                    <exclude>WEB-INF/lib/gwc-*.jar</exclude>
+                                    <exclude>WEB-INF/lib/*-gwc-*.jar</exclude>
                                 </excludes>
                         </overlay>
                     </overlays>


### PR DESCRIPTION
Geowebcache is a core plugin that we don't want - we use squid for caching and just having geowebcache installed adds minutes to the startup time.