### PR TITLE
Prevent GoGoDuck from jamming

### DIFF
--- a/src/extension/wps/src/main/java/au/org/emii/gogoduck/worker/GoGoDuck.java
+++ b/src/extension/wps/src/main/java/au/org/emii/gogoduck/worker/GoGoDuck.java
@@ -389,6 +389,7 @@ public class GoGoDuck {
         logger.info(command.toString());
 
         ProcessBuilder builder = new ProcessBuilder(command);
+        builder.redirectErrorStream(true);
         Map<String, String> environ = builder.environment();
 
         final Process process = builder.start();


### PR DESCRIPTION
Redirect stderr to stdout. Otherwise it'll wait for process
indefinitely, until stderr is consumed.

Fixes #90 