### PR TITLE
Use dbcp connection pooling for mvn jetty:run

### DIFF
--- a/src/main/pom.xml
+++ b/src/main/pom.xml
@@ -139,6 +139,11 @@
                         <artifactId>liquibase-core</artifactId>
                         <version>3.4.1</version>
                     </dependency>
+                    <dependency>
+                        <groupId>commons-dbcp</groupId>
+                        <artifactId>commons-dbcp</artifactId>
+                        <version>1.4</version>
+                    </dependency>
                 </dependencies>
             </plugin>
        </plugins>

--- a/src/main/src/jetty/context-sample.xml
+++ b/src/main/src/jetty/context-sample.xml
@@ -4,13 +4,23 @@
        <Arg></Arg>
        <Arg>jdbc/default</Arg>
        <Arg>
-          <New class="org.postgresql.ds.PGSimpleDataSource">
-             <Set name="User">geoserver</Set>
-             <Set name="Password">geoserver</Set>
-             <Set name="DatabaseName">geoserver</Set>
-             <Set name="ServerName">localhost</Set>
-             <Set name="PortNumber">5432</Set>
-          </New>
+           <New class="org.apache.commons.dbcp.BasicDataSource">
+              <Set name="driverClassName">org.postgresql.Driver</Set>
+              <Set name="url">jdbc:postgresql://localhost:5432/geoserver</Set>
+              <Set name="username">geoserver</Set>
+              <Set name="password">geoserver</Set>
+              <Set name="validationQuery">SELECT 1</Set>
+              <Set name="maxActive">10</Set>
+              <Set name="maxIdle">5</Set>
+              <Set name="maxWait">-1</Set>
+              <Set name="testOnBorrow">true</Set>
+              <Set name="testWhileIdle">true</Set>
+              <Set name="testOnReturn">true</Set>
+              <Set name="timeBetweenEvictionRunsMillis">30000</Set>
+              <Set name="numTestsPerEvictionRun">3</Set>
+              <Set name="minEvictableIdleTimeMillis">60000</Set>
+              <Set name="defaultAutoCommit">true</Set>
+           </New>
        </Arg>
     </New>
 </Configure>


### PR DESCRIPTION
Use dbcp connection pooling as per tomcat setup so that connection pooling issues can be reproduced and investigated locally.

NB: this requires context.xml on local clones of this repository to be updated as per changes made to context-sample.xml to run mvn jetty:run after these changes.