### PR TITLE
GoGoDuck can use Feature Source

### DIFF
--- a/src/extension/ncwms/src/main/java/au/org/emii/geoserver/wms/UrlIndexFeatureSource.java
+++ b/src/extension/ncwms/src/main/java/au/org/emii/geoserver/wms/UrlIndexFeatureSource.java
@@ -85,9 +85,9 @@ public class UrlIndexFeatureSource implements UrlIndexInterface {
                 LOGGER.log(Level.INFO, String.format("Processing timestamp '%s'", timestamp));
                 timesOfDay.add(getTimeFromDate(timestamp));
             }
-       } finally {
-           iterator.close();
-       }
+        } finally {
+            iterator.close();
+        }
 
         return timesOfDay;
     }

--- a/src/extension/wps/src/main/java/au/org/emii/gogoduck/worker/FeatureSourceIndexReader.java
+++ b/src/extension/wps/src/main/java/au/org/emii/gogoduck/worker/FeatureSourceIndexReader.java
@@ -1,0 +1,83 @@
+package au.org.emii.gogoduck.worker;
+
+import java.io.IOException;
+import java.net.URI;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.geoserver.catalog.Catalog;
+import org.geotools.filter.text.cql2.CQL;
+import org.geotools.filter.text.cql2.CQLException;
+import org.geotools.data.simple.SimpleFeatureCollection;
+import org.geotools.data.simple.SimpleFeatureIterator;
+import org.geotools.data.simple.SimpleFeatureSource;
+import org.geotools.data.Query;
+import org.opengis.filter.Filter;
+import org.opengis.feature.simple.SimpleFeature;
+
+public class FeatureSourceIndexReader implements IndexReader {
+    private static final Logger logger = LoggerFactory.getLogger(FeatureSourceIndexReader.class);
+
+    private Catalog catalog = null;
+    private UserLog userLog = null;
+
+    public FeatureSourceIndexReader(UserLog userLog, Catalog catalog) {
+        this.userLog = userLog;
+        this.catalog = catalog;
+    }
+
+    @Override
+    public URIList getUriList(String profile, String timeField, String urlField, SubsetParameters subset) throws GoGoDuckException {
+        String timeCoverageStart = subset.get("TIME").start;
+        String timeCoverageEnd = subset.get("TIME").end;
+
+        URIList uriList = new URIList();
+
+        // TODO Should include also workspace, but works also without
+        String typeName = profile;
+
+        Filter cqlFilter = null;
+
+        try {
+            cqlFilter = CQL.toFilter(
+                String.format("%s >= '%s' AND %s <= '%s'",
+                    timeField, timeCoverageStart,
+                    timeField, timeCoverageEnd)
+            );
+        } catch (CQLException e) {
+            throw new GoGoDuckException(e.getMessage());
+        }
+
+        Query query = new Query(typeName, cqlFilter, new String[]{urlField});
+
+        SimpleFeatureIterator iterator = null;
+        try {
+            iterator = getFeatures(typeName, query);
+        } catch (IOException e) {
+            throw new GoGoDuckException(e.getMessage());
+        }
+
+        try {
+            while (iterator.hasNext()) {
+                SimpleFeature feature = iterator.next();
+                String url = (String) feature.getAttribute(urlField);
+                logger.info(String.format("Processing url '%s'", url));
+                uriList.add(new URI(url));
+            }
+        } catch (Exception e) {
+            userLog.log("We could not obtain list of URLs, does the collection still exist?");
+            throw new GoGoDuckException(String.format("Could not obtain list of URLs: '%s'", e.getMessage()));
+        } finally {
+            iterator.close();
+        }
+
+        return uriList;
+    }
+
+    private SimpleFeatureIterator getFeatures(String typeName, Query query) throws IOException {
+        SimpleFeatureSource featureSource = (SimpleFeatureSource) catalog.getFeatureTypeByName(typeName).getFeatureSource(null, null);
+        SimpleFeatureCollection collection = featureSource.getFeatures(query);
+        return collection.features();
+    }
+}

--- a/src/extension/wps/src/main/java/au/org/emii/gogoduck/worker/HttpIndexReader.java
+++ b/src/extension/wps/src/main/java/au/org/emii/gogoduck/worker/HttpIndexReader.java
@@ -1,0 +1,99 @@
+package au.org.emii.gogoduck.worker;
+
+import java.io.BufferedInputStream;
+import java.io.DataInputStream;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class HttpIndexReader implements IndexReader {
+    private static final Logger logger = LoggerFactory.getLogger(HttpIndexReader.class);
+
+    protected String geoserver = null;
+    private UserLog userLog = null;
+
+    public HttpIndexReader(UserLog userLog, String geoserver) {
+        this.userLog = userLog;
+        this.geoserver = geoserver;
+    }
+
+    @Override
+    public URIList getUriList(String profile, String timeField, String urlField, SubsetParameters subset) throws GoGoDuckException {
+        String timeCoverageStart = subset.get("TIME").start;
+        String timeCoverageEnd = subset.get("TIME").end;
+
+        URIList uriList = new URIList();
+
+        try {
+            String downloadUrl = String.format("%s/wfs", geoserver);
+            String cqlFilter = String.format("%s >= %s AND %s <= %s",
+                timeField, timeCoverageStart, timeField, timeCoverageEnd
+            );
+
+            Map<String, String> params = new HashMap<String, String>();
+            params.put("typeName", profile);
+            params.put("SERVICE", "WFS");
+            params.put("outputFormat", "csv");
+            params.put("REQUEST", "GetFeature");
+            params.put("VERSION", "1.0.0");
+            params.put("CQL_FILTER", cqlFilter);
+
+            byte[] postDataBytes = encodeMapForPostRequest(params);
+
+            URL url = new URL(downloadUrl);
+            HttpURLConnection conn = (HttpURLConnection)url.openConnection();
+            conn.setRequestMethod("GET");
+            conn.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
+            conn.setRequestProperty("Content-Length", String.valueOf(postDataBytes.length));
+            conn.setDoOutput(true);
+            conn.getOutputStream().write(postDataBytes);
+
+            InputStream inputStream = conn.getInputStream();
+            DataInputStream dataInputStream = new DataInputStream(new BufferedInputStream(inputStream));
+
+            logger.info(String.format("Getting list of files from '%s'", downloadUrl));
+            logger.debug(String.format("Parameters: '%s'", new String(postDataBytes)));
+            String line = null;
+            Integer i = 0;
+            while ((line = dataInputStream.readLine()) != null) {
+                if (i > 0) { // Skip first line - it's the headers
+                    String[] lineParts = line.split(",");
+                    uriList.add(new URI(lineParts[2]));
+                }
+                i++;
+            }
+        }
+        catch (Exception e) {
+            userLog.log("We could not obtain list of URLs, does the collection still exist?");
+            throw new GoGoDuckException(String.format("Could not obtain list of URLs: '%s'", e.getMessage()));
+        }
+
+        return uriList;
+    }
+
+    private byte[] encodeMapForPostRequest(Map<String, String> params) {
+        byte[] postDataBytes = null;
+        try {
+            StringBuilder postData = new StringBuilder();
+            for (Map.Entry<String, String> param : params.entrySet()) {
+                if (postData.length() != 0) postData.append('&');
+                postData.append(URLEncoder.encode(param.getKey(), "UTF-8"));
+                postData.append('=');
+                postData.append(URLEncoder.encode(String.valueOf(param.getValue()), "UTF-8"));
+            }
+            postDataBytes = postData.toString().getBytes("UTF-8");
+        }
+        catch (Exception e) {
+            logger.error(String.format("Error encoding parameters: '%s'", e.getMessage()));
+        }
+
+        return postDataBytes;
+    }
+}

--- a/src/extension/wps/src/main/java/au/org/emii/gogoduck/worker/IndexReader.java
+++ b/src/extension/wps/src/main/java/au/org/emii/gogoduck/worker/IndexReader.java
@@ -1,0 +1,5 @@
+package au.org.emii.gogoduck.worker;
+
+public interface IndexReader {
+    public URIList getUriList(String profile, String timeField, String urlField, SubsetParameters subset) throws GoGoDuckException;
+}

--- a/src/extension/wps/src/main/java/au/org/emii/wps/GoGoDuckProcess.java
+++ b/src/extension/wps/src/main/java/au/org/emii/wps/GoGoDuckProcess.java
@@ -6,6 +6,7 @@ import au.org.emii.gogoduck.worker.URLMangler;
 import au.org.emii.notifier.HttpNotifier;
 import org.apache.commons.io.FilenameUtils;
 import org.geoserver.config.GeoServer;
+import org.geoserver.catalog.Catalog;
 import org.geoserver.platform.GeoServerResourceLoader;
 import org.geoserver.wps.process.FileRawData;
 import org.geoserver.wps.resource.WPSResourceManager;
@@ -32,6 +33,7 @@ import java.util.Map;
 public class GoGoDuckProcess extends AbstractNotifierProcess {
     static final Logger logger = LoggerFactory.getLogger(GoGoDuck.class);
 
+    private final Catalog catalog;
     private final GeoServerResourceLoader resourceLoader;
 
     private final String CONFIG_FILE = "wps/gogoduck.xml";
@@ -43,8 +45,9 @@ public class GoGoDuckProcess extends AbstractNotifierProcess {
     private final String THREAD_COUNT_DEFAULT = "0";
 
     public GoGoDuckProcess(WPSResourceManager resourceManager, HttpNotifier httpNotifier,
-            GeoServerResourceLoader resourceLoader, GeoServer geoserver) {
+            Catalog catalog, GeoServerResourceLoader resourceLoader, GeoServer geoserver) {
         super(resourceManager, httpNotifier, geoserver);
+        this.catalog = catalog;
         this.resourceLoader = resourceLoader;
     }
 
@@ -77,7 +80,7 @@ public class GoGoDuckProcess extends AbstractNotifierProcess {
 
             final String filePath = outputFile.toPath().toAbsolutePath().toString();
 
-            GoGoDuck ggd = new GoGoDuck(getBaseUrl(), layer, subset, filePath, fileLimit);
+            GoGoDuck ggd = new GoGoDuck(catalog, layer, subset, filePath, fileLimit);
 
             ggd.setTmpDir(getWorkingDir());
             ggd.setThreadCount(threadCount);

--- a/src/extension/wps/src/main/resources/applicationContext.xml
+++ b/src/extension/wps/src/main/resources/applicationContext.xml
@@ -14,7 +14,7 @@
                 <entry key="^CARS2009_World_monthly.nc$"    value="/mnt/imos-t3/climatology/CARS/2009/eMII-product/CARS2009_World_monthly.nc"/>
                 <entry key="^/mnt/imos-t3/"                 value="https://data.aodn.org.au/"/>
                 <entry key="^/mnt/opendap/2/SRS/"           value="https://thredds.aodn.org.au/thredds/fileServer/srs/"/>
-                <entry key="^IMOS/"                         value="https://imos-data.aodn.org.au/IMOS/"/>
+                <entry key="^IMOS/"                         value="http://imos-data.aodn.org.au/IMOS/"/>
             </map>
         </property>
     </bean>

--- a/src/extension/wps/src/main/resources/applicationContext.xml
+++ b/src/extension/wps/src/main/resources/applicationContext.xml
@@ -4,8 +4,9 @@
     <bean id="goGoDuckProcess" class="au.org.emii.wps.GoGoDuckProcess">
         <constructor-arg index="0" ref="wpsResourceManager"/>
         <constructor-arg index="1" ref="retryingHttpNotifier"/>
-        <constructor-arg index="2" ref="resourceLoader"/>
-        <constructor-arg index="3" ref="geoServer"/>
+        <constructor-arg index="2" ref="catalog"/>
+        <constructor-arg index="3" ref="resourceLoader"/>
+        <constructor-arg index="4" ref="geoServer"/>
 
         <property name="urlMangling">
             <map>

--- a/src/extension/wps/src/test/java/au/org/emii/gogoduck/worker/GoGoDuckModuleTest.java
+++ b/src/extension/wps/src/test/java/au/org/emii/gogoduck/worker/GoGoDuckModuleTest.java
@@ -25,7 +25,7 @@ public class GoGoDuckModuleTest {
     @Before
     public void beforeEach() {
         ggdm = new GoGoDuckModule();
-        ggdm.init("", "", "TIME,1,2;LONGITUDE,2,3", null);
+        ggdm.init("", new HttpIndexReader(null, ""), "TIME,1,2;LONGITUDE,2,3", null);
     }
 
     @Test
@@ -57,7 +57,7 @@ public class GoGoDuckModuleTest {
         Files.copy(sampleNetcdf.toPath(), tmpFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
 
         ggdm = new GoGoDuckModule_test();
-        ggdm.init("", "", "TIME,1,2;LONGITUDE,2,3", null);
+        ggdm.init("", new HttpIndexReader(null, ""), "TIME,1,2;LONGITUDE,2,3", null);
         ggdm.updateMetadata(tmpFile.toPath());
 
         // Verify attribute was written to file


### PR DESCRIPTION
If used from the command line, GoGoDuck still uses regular WFS, but
when used as a WPS service, it'll use the provided Geoserver
catalog and query it, preventing another thread from spawning and
potentially causing a deadlock.