### PR TITLE
GoGoDuck URL mangling can be set from config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,12 @@
                 <artifactId>slf4j-simple</artifactId>
                 <version>1.6.3</version>
             </dependency>
+            <dependency>
+                <groupId>dom4j</groupId>
+                <artifactId>dom4j</artifactId>
+                <version>1.6.1</version>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 

--- a/src/extension/ncwms/pom.xml
+++ b/src/extension/ncwms/pom.xml
@@ -36,7 +36,6 @@
         <dependency>
             <groupId>dom4j</groupId>
             <artifactId>dom4j</artifactId>
-            <version>1.6.1</version>
         </dependency>
         <dependency>
             <groupId>jaxen</groupId>

--- a/src/extension/wps/pom.xml
+++ b/src/extension/wps/pom.xml
@@ -65,6 +65,10 @@
             <artifactId>slf4j-log4j12</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>dom4j</groupId>
+            <artifactId>dom4j</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.geotools.jdbc</groupId>

--- a/src/extension/wps/src/main/java/au/org/emii/gogoduck/worker/GoGoDuckModule_cars.java
+++ b/src/extension/wps/src/main/java/au/org/emii/gogoduck/worker/GoGoDuckModule_cars.java
@@ -2,8 +2,8 @@ package au.org.emii.gogoduck.worker;
 
 import java.net.URI;
 
-public abstract  class GoGoDuckModule_cars extends GoGoDuckModule {
-    private static final String CARS_FILENAME = "CARS2009_Australia_weekly.nc";
+public abstract class GoGoDuckModule_cars extends GoGoDuckModule {
+    private static final String CARS_FILENAME = "AODN/Australian_Government/CSIRO/Climatology/CARS/2009/eMII-product/CARS2009_Australia_weekly.nc";
 
     @Override
     public SubsetParameters getSubsetParameters() {

--- a/src/extension/wps/src/main/java/au/org/emii/gogoduck/worker/GoGoDuckModule_cars_australia_weekly.java
+++ b/src/extension/wps/src/main/java/au/org/emii/gogoduck/worker/GoGoDuckModule_cars_australia_weekly.java
@@ -4,7 +4,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 
 public class GoGoDuckModule_cars_australia_weekly extends GoGoDuckModule_cars {
-    private static final String CARS_FILENAME = "CARS2009_Australia_weekly.nc";
+    private static final String CARS_FILENAME = "AODN/Australian_Government/CSIRO/Climatology/CARS/2009/eMII-product/CARS2009_Australia_weekly.nc";
 
     @Override
     public URI getCarsFilename() {

--- a/src/extension/wps/src/main/java/au/org/emii/gogoduck/worker/GoGoDuckModule_cars_world_monthly.java
+++ b/src/extension/wps/src/main/java/au/org/emii/gogoduck/worker/GoGoDuckModule_cars_world_monthly.java
@@ -4,7 +4,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 
 public class GoGoDuckModule_cars_world_monthly extends GoGoDuckModule_cars {
-    private static final String CARS_FILENAME = "CARS2009_World_monthly.nc";
+    private static final String CARS_FILENAME = "AODN/Australian_Government/CSIRO/Climatology/CARS/2009/eMII-product/CARS2009_World_monthly.nc";
 
     @Override
     public URI getCarsFilename() {

--- a/src/extension/wps/src/main/java/au/org/emii/gogoduck/worker/Main.java
+++ b/src/extension/wps/src/main/java/au/org/emii/gogoduck/worker/Main.java
@@ -9,15 +9,7 @@ public class Main {
 
     private static Map<String, String> urlMangling = new HashMap<String, String>();
     static {
-        urlMangling.put("^CARS2009_Australia_weekly.nc$", "/mnt/imos-t3/climatology/CARS/2009/eMII-product/CARS2009_Australia_weekly.nc");
-        urlMangling.put("^CARS2009_World_monthly.nc$", "/mnt/imos-t3/climatology/CARS/2009/eMII-product/CARS2009_World_monthly.nc");
-        urlMangling.put("^/mnt/imos-t3/", "https://data.aodn.org.au/");
-        urlMangling.put("^/mnt/opendap/2/SRS/", "https://thredds.aodn.org.au/thredds/fileServer/IMOS/SRS/");
-        urlMangling.put("^IMOS/", "http://imos-data.aodn.org.au/IMOS/");
-    }
-
-    public static Map<String, String> getUrlMangling() {
-        return urlMangling;
+        urlMangling.put("^", "http://imos-data.aodn.org.au/");
     }
 
     public static void usage(Options options) {
@@ -28,7 +20,7 @@ public class Main {
     }
 
     public static void main(String[] args) {
-        URLMangler.setUrlManglingMap(getUrlMangling());
+        URLMangler.setUrlManglingMap(urlMangling);
 
         Options options = new Options();
 

--- a/src/extension/wps/src/main/resources/applicationContext.xml
+++ b/src/extension/wps/src/main/resources/applicationContext.xml
@@ -7,16 +7,6 @@
         <constructor-arg index="2" ref="catalog"/>
         <constructor-arg index="3" ref="resourceLoader"/>
         <constructor-arg index="4" ref="geoServer"/>
-
-        <property name="urlMangling">
-            <map>
-                <entry key="^CARS2009_Australia_weekly.nc$" value="/mnt/imos-t3/climatology/CARS/2009/eMII-product/CARS2009_Australia_weekly.nc"/>
-                <entry key="^CARS2009_World_monthly.nc$"    value="/mnt/imos-t3/climatology/CARS/2009/eMII-product/CARS2009_World_monthly.nc"/>
-                <entry key="^/mnt/imos-t3/"                 value="https://data.aodn.org.au/"/>
-                <entry key="^/mnt/opendap/2/SRS/"           value="https://thredds.aodn.org.au/thredds/fileServer/srs/"/>
-                <entry key="^IMOS/"                         value="http://imos-data.aodn.org.au/IMOS/"/>
-            </map>
-        </property>
     </bean>
 
     <bean id="retryingHttpNotifier" class="au.org.emii.notifier.RetryingHttpNotifier">


### PR DESCRIPTION
GoGoDuck URL mangling can be set from geoserver data dir. This is
not being set as a bean property any more and provides more
flexibility.

Also fix CARS URLs, so they point to the right place of CARS at
the moment on S3.

Fixes #117.