### PR TITLE
Upgrade to GeoServer 2.8.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <url>http://www.emii.org.au</url>
 
     <properties>
-        <geoserver.version>2.8.0</geoserver.version>
+        <geoserver.version>2.8.2</geoserver.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.resources.sourceEncoding>${project.build.sourceEncoding}</project.resources.sourceEncoding>
     </properties>

--- a/src/extension/csv-with-metadata-header/pom.xml
+++ b/src/extension/csv-with-metadata-header/pom.xml
@@ -7,7 +7,6 @@
     <artifactId>csv-with-metadata-header</artifactId>
     <packaging>jar</packaging>
     <name>CSV With Metadata Header (jar)</name>
-    <version>1.0.0</version>
 
     <parent>
         <groupId>org.geoserver</groupId>

--- a/src/extension/ncwms/pom.xml
+++ b/src/extension/ncwms/pom.xml
@@ -7,7 +7,6 @@
     <artifactId>ncwms</artifactId>
     <packaging>jar</packaging>
     <name>GeoServer Ncwms (jar)</name>
-    <version>1.0.0</version>
 
     <parent>
         <groupId>org.geoserver</groupId>
@@ -28,7 +27,6 @@
         <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
-            <version>1.5</version>
         </dependency>
         <dependency>
             <groupId>net.sf.json-lib</groupId>
@@ -48,7 +46,6 @@
         <dependency>
             <groupId>org.easymock</groupId>
             <artifactId>easymock</artifactId>
-            <version>3.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/extension/wps/pom.xml
+++ b/src/extension/wps/pom.xml
@@ -7,7 +7,6 @@
     <artifactId>wps</artifactId>
     <packaging>jar</packaging>
     <name>WPS artifact (jar)</name>
-    <version>1.0.0</version>
 
     <parent>
         <groupId>org.geoserver</groupId>

--- a/src/main/pom.xml
+++ b/src/main/pom.xml
@@ -56,7 +56,6 @@
         <dependency>
             <groupId>org.geoserver.extension</groupId>
             <artifactId>gs-wps-core</artifactId>
-            <version>${geoserver.version}</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
@@ -73,7 +72,6 @@
         <dependency>
             <groupId>org.geotools.jdbc</groupId>
             <artifactId>gt-jdbc-sqlserver</artifactId>
-            <version>12.1</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Use matching gt-jdbc-sqlserver version
Use managed versions of joda-time and easymock
Use parent version for extensions so we don't have to update the version in multiple places (and fixes warnings for me in eclipse)