### PR TITLE
Subset multi-time files on requested time (GoGoDuck)

### DIFF
--- a/src/extension/wps/src/main/java/au/org/emii/gogoduck/worker/GoGoDuckModule.java
+++ b/src/extension/wps/src/main/java/au/org/emii/gogoduck/worker/GoGoDuckModule.java
@@ -95,11 +95,7 @@ public class GoGoDuckModule {
     }
 
     public SubsetParameters getSubsetParameters() {
-        // Remove time parameter as we don't need to subset on it, we already
-        // have only files that are in the correct time range
-        SubsetParameters subsetParametersNoTime = new SubsetParameters(subset);
-        subsetParametersNoTime.remove("TIME");
-        return subsetParametersNoTime;
+        return new SubsetParameters(subset);
     }
 
     public static GoGoDuckModule newInstance(String profile, IndexReader indexReader, String subset, UserLog userLog) {

--- a/src/extension/wps/src/main/java/au/org/emii/gogoduck/worker/GoGoDuckModule_cars_australia_weekly.java
+++ b/src/extension/wps/src/main/java/au/org/emii/gogoduck/worker/GoGoDuckModule_cars_australia_weekly.java
@@ -4,7 +4,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 
 public class GoGoDuckModule_cars_australia_weekly extends GoGoDuckModule_cars {
-    private static final String CARS_FILENAME = "AODN/Australian_Government/CSIRO/Climatology/CARS/2009/eMII-product/CARS2009_Australia_weekly.nc";
+    private static final String CARS_FILENAME = "CSIRO/Climatology/CARS/2009/eMII-product/CARS2009_Australia_weekly.nc";
 
     @Override
     public URI getCarsFilename() {

--- a/src/extension/wps/src/main/java/au/org/emii/gogoduck/worker/GoGoDuckModule_cars_world_monthly.java
+++ b/src/extension/wps/src/main/java/au/org/emii/gogoduck/worker/GoGoDuckModule_cars_world_monthly.java
@@ -4,7 +4,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 
 public class GoGoDuckModule_cars_world_monthly extends GoGoDuckModule_cars {
-    private static final String CARS_FILENAME = "AODN/Australian_Government/CSIRO/Climatology/CARS/2009/eMII-product/CARS2009_World_monthly.nc";
+    private static final String CARS_FILENAME = "CSIRO/Climatology/CARS/2009/eMII-product/CARS2009_World_monthly.nc";
 
     @Override
     public URI getCarsFilename() {

--- a/src/extension/wps/src/test/java/au/org/emii/gogoduck/worker/GoGoDuckModuleTest.java
+++ b/src/extension/wps/src/test/java/au/org/emii/gogoduck/worker/GoGoDuckModuleTest.java
@@ -1,19 +1,16 @@
 package au.org.emii.gogoduck.worker;
 
-import org.junit.Before;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 import java.io.File;
-import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import org.junit.Before;
+import org.junit.Test;
 
 import ucar.nc2.Attribute;
 import ucar.nc2.NetcdfFile;
@@ -26,18 +23,6 @@ public class GoGoDuckModuleTest {
     public void beforeEach() {
         ggdm = new GoGoDuckModule();
         ggdm.init("", new HttpIndexReader(null, ""), "TIME,1,2;LONGITUDE,2,3", null);
-    }
-
-    @Test
-    public void testGetSubsetParameters() throws Exception {
-        // Make sure it removes `TIME` subset parameter
-        assertFalse(ggdm.getSubsetParameters().containsKey("TIME"));
-
-        // But did that only on a copy of the subset parameters
-        Field privateSubset = GoGoDuckModule.class.getDeclaredField("subset");
-        privateSubset.setAccessible(true);
-        SubsetParameters sp = (SubsetParameters) privateSubset.get(ggdm);
-        assertTrue(sp.containsKey("TIME"));
     }
 
     public class GoGoDuckModule_test extends GoGoDuckModule {


### PR DESCRIPTION
Pass time onto subset operations by default - required for multi time files such as CARS

Can be overridden on subclasses - i.e. SRS

Also changed location of CARS files to current location.  Its not ideal to do that here and should be changed when the location can be sourced form the database (required for ncwms abomination as well).