### PR TITLE
Handling empty values in template ''

### DIFF
--- a/src/extension/wps/src/main/java/au/org/emii/ncdfgenerator/AttributeValueParser.java
+++ b/src/extension/wps/src/main/java/au/org/emii/ncdfgenerator/AttributeValueParser.java
@@ -1,5 +1,7 @@
 package au.org.emii.ncdfgenerator;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import ucar.ma2.Array;
 import ucar.ma2.DataType;
 
@@ -8,6 +10,8 @@ import java.util.List;
 
 class AttributeValueParser implements IAttributeValueParser {
     // follows ncdf string conventions
+
+    private static final Logger logger = LoggerFactory.getLogger(AttributeValueParser.class);
 
     private int skipWhite(String s, int pos) {
         while (Character.isSpaceChar(peekChar(s, pos))) {
@@ -212,6 +216,11 @@ class AttributeValueParser implements IAttributeValueParser {
         ++pos2;
         while (peekChar(s, pos2) != closeChar) {
             ++pos2;
+            if (pos2 == s.length()) {
+                // Catch case of non terminating netCdf attribute
+                logger.debug(String.format("Looks like string attribute not properly terminated %s", s));
+                return null;
+            }
         }
         ++pos2;
         String value = s.substring(pos + 1, pos2 - 1);


### PR DESCRIPTION
# Testing Instructions

1. Point to prod database
2. Point to geoserver-config
3. Replace geoserver-config/workspaces/imos/JNDI_soop_sst/soop_sst_nrt_trajectory_data with [netcdf.xml](https://github.com/aodn/geoserver-build/files/502099/netcdf.txt) @bpasquer  will make the geoserver-config changes for all the relevant records

**Sample Request**

```
<?xml version="1.0" encoding="UTF-8"?>
<wps:Execute xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:wps="http://www.opengis.net/wps/1.0.0" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:xlink="http://www.w3.org/1999/xlink" service="WPS" version="1.0.0">
  <ows:Identifier>gs:NetcdfOutput</ows:Identifier>
  <wps:DataInputs>
    <wps:Input>
      <ows:Identifier>typeName</ows:Identifier>
      <wps:Data>
        <wps:LiteralData>imos:soop_sst_nrt_trajectory_data</wps:LiteralData>
      </wps:Data>
    </wps:Input>
    <wps:Input>
      <ows:Identifier>cqlFilter</ows:Identifier>
      <wps:Data>
        <wps:LiteralData>INTERSECTS(geom,POLYGON((145.42602539063 -38.859619140625,145.42602539063 -38.508056640625,144.94262695313 -38.508056640625,144.94262695313 -38.859619140625,145.42602539063 -38.859619140625)))</wps:LiteralData>
      </wps:Data>
    </wps:Input>
    <wps:Input>
      <ows:Identifier>callbackUrl</ows:Identifier>
      <wps:Data>
        <wps:LiteralData>http://portal-rc.aodn.org.au/wps/jobComplete</wps:LiteralData>
      </wps:Data>
    </wps:Input>
    <wps:Input>
      <ows:Identifier>callbackParams</ows:Identifier>
      <wps:Data>
        <wps:LiteralData>email.to=benedicte.pasquer@utas.edu.au</wps:LiteralData>
      </wps:Data>
    </wps:Input>
  </wps:DataInputs>
  <wps:ResponseForm>
    <wps:ResponseDocument lineage="false" status="true" storeExecuteResponse="true">
      <wps:Output asReference="true" mimeType="application/zip">
        <ows:Identifier>result</ows:Identifier>
      </wps:Output>
    </wps:ResponseDocument>
  </wps:ResponseForm>
</wps:Execute>
```

