### PR TITLE
Allow more than 2232 files to be aggregated

### DIFF
--- a/src/extension/wps/pom.xml
+++ b/src/extension/wps/pom.xml
@@ -95,6 +95,10 @@
             <artifactId>core</artifactId>
             <version>1.0.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-exec</artifactId>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Instead of passing the files to be aggregated on the command line (limited to 2232)
pass the files to be aggregated on stdin which has no such limit.

