### PR TITLE
Add '--no_tmp_fl' argument to ncrcat aggregate command

### DIFF
--- a/src/extension/wps/src/main/java/au/org/emii/gogoduck/worker/GoGoDuck.java
+++ b/src/extension/wps/src/main/java/au/org/emii/gogoduck/worker/GoGoDuck.java
@@ -431,6 +431,7 @@ public class GoGoDuck {
         command.addArgument("-4");
         command.addArgument("-h");
         command.addArgument("-O");
+        command.addArgument("--no_tmp_fl");
 
         if (files.size() == 1) {
             // Special case where we have only 1 file


### PR DESCRIPTION
@jonescc As I understand it, this should remove the tmp file creation