### PR TITLE
Fix issue appending file multiple times when file contains more than …

### DIFF
--- a/src/extension/wps/src/main/java/au/org/emii/download/DownloadRequest.java
+++ b/src/extension/wps/src/main/java/au/org/emii/download/DownloadRequest.java
@@ -22,4 +22,22 @@ public class DownloadRequest {
         return size;
     }
 
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        DownloadRequest that = (DownloadRequest) o;
+
+        if (size != that.size) return false;
+        return url != null ? url.equals(that.url) : that.url == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = url != null ? url.hashCode() : 0;
+        result = 31 * result + (int) (size ^ (size >>> 32));
+        return result;
+    }
 }

--- a/src/extension/wps/src/test/java/au/org/emii/download/DownloadRequestTest.java
+++ b/src/extension/wps/src/test/java/au/org/emii/download/DownloadRequestTest.java
@@ -1,0 +1,32 @@
+package au.org.emii.download;
+
+import org.junit.Test;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import static org.junit.Assert.*;
+
+/**
+ * DownloadRequest unit tests
+ */
+public class DownloadRequestTest {
+    @Test
+    public void testNoDuplicatesInLinkedHashSet() throws MalformedURLException {
+        Set<DownloadRequest> downloads = new LinkedHashSet<>();
+
+        downloads.add(new DownloadRequest(new URL("http://example.com/downloads/file1.text"), 5325326L));
+        downloads.add(new DownloadRequest(new URL("http://example.com/downloads/file2.text"), 532532L));
+        downloads.add(new DownloadRequest(new URL("http://example.com/downloads/file1.text"), 5325326L));
+
+        assertArrayEquals(new DownloadRequest[]{
+                new DownloadRequest(new URL("http://example.com/downloads/file1.text"), 5325326L),
+                new DownloadRequest(new URL("http://example.com/downloads/file2.text"), 532532L)
+            }, downloads.toArray()
+        );
+    }
+
+}
+


### PR DESCRIPTION
…one time value.

Override equals/hasCode methods so linked hashset will not add the same download more than once.