### PR TITLE
EnabledFilters Extension: Merge workspace and layer parameters

### DIFF
--- a/src/extension/layer-filters/src/main/java/au/org/emii/geoserver/extensions/filters/LayerFiltersService.java
+++ b/src/extension/layer-filters/src/main/java/au/org/emii/geoserver/extensions/filters/LayerFiltersService.java
@@ -187,6 +187,7 @@ public class LayerFiltersService {
     }
 
     private void respondWithDocument(HttpServletResponse response, Document document) throws TransformerException, IOException {
+        response.addHeader("Content-Type", "text/xml");
         TransformerFactory transformerFactory = TransformerFactory.newInstance();
         Transformer transformer = transformerFactory.newTransformer();
         DOMSource source = new DOMSource(document);


### PR DESCRIPTION
Allow workspace and layer name to be specified together in a single parameter (but still accept old way as well). Return a content-type so we're conforming to web standards and so geowebcache doesn't get whiney