### PR TITLE
Fixes #256.   

### DIFF
--- a/src/extension/wps/src/main/java/au/org/emii/aggregator/index/IndexChunk.java
+++ b/src/extension/wps/src/main/java/au/org/emii/aggregator/index/IndexChunk.java
@@ -1,0 +1,23 @@
+package au.org.emii.aggregator.index;
+
+/**
+ * Index chunk
+ */
+public class IndexChunk {
+    private int[] offset;
+    private int[] shape;
+
+    public IndexChunk(int[] offset, int[] shape) {
+        this.offset = offset.clone();
+        this.shape = shape.clone();
+    }
+
+
+    public int[] getOffset() {
+        return offset.clone();
+    }
+
+    public int[] getShape() {
+        return shape.clone();
+    }
+}

--- a/src/extension/wps/src/main/java/au/org/emii/aggregator/index/IndexChunkIterator.java
+++ b/src/extension/wps/src/main/java/au/org/emii/aggregator/index/IndexChunkIterator.java
@@ -1,0 +1,138 @@
+package au.org.emii.aggregator.index;
+
+import ucar.ma2.Index;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+/**
+ * An index chunk iterator which returns the next chunk of the index up to the requested maximum number of elements.
+ * May return a chunk smaller than the maximum number of elements if that's all that's left.
+ * Used to read up to the requested maximum number of elements from a variable at a time.
+ */
+public class IndexChunkIterator implements Iterator<IndexChunk> {
+    private final int[] shape;
+    private final long maxChunkElems;
+    private final int rank;
+    private final long[] stride;
+    private final long size;
+
+    private int[] currentOffset;
+
+    /**
+     * Create a new iterator to return chunks of the index up to {@code maxChunkElems} at a time for
+     * an array of shape {@code shape}
+     * @param shape
+     * @param maxChunkElems
+     */
+    public IndexChunkIterator(int[] shape, long maxChunkElems) {
+        this.shape = shape.clone();
+        this.maxChunkElems = maxChunkElems;
+        this.rank = shape.length;
+        this.stride = buildStride(shape);
+        this.size = calcSize(shape);
+        this.currentOffset = new int[rank];
+    }
+
+    /**
+     * Are there more index chunks to read?
+     */
+
+    @Override
+    public boolean hasNext() {
+        return getCurrent1DOffset() < size;
+    }
+
+    /**
+     * Return the next index chunk
+     */
+    @Override
+    public IndexChunk next() {
+        if (!hasNext()) {
+            throw new NoSuchElementException();
+        }
+        IndexChunk next = new IndexChunk(currentOffset, getChunkShape());
+        setCurrent1DOffset(getCurrent1DOffset() + Index.computeSize(next.getShape()));
+        return next;
+    }
+
+    /**
+     * Remove is not supported
+     */
+    @Override
+    public void remove() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Return current offset in a 1D backing array of shape {@code shape}
+     */
+    private long getCurrent1DOffset() {
+        long currentElement = 0L;
+
+        for (int dim=0; dim<rank; dim++) {
+            currentElement += currentOffset[dim] * stride[dim];
+        }
+
+        return currentElement;
+    }
+
+    /**
+     * Set current offset from an offset in a 1D backing array of shape {@code shape}
+     */
+    private void setCurrent1DOffset(long value) {
+        long remainder = value;
+
+        for (int dim=0; dim<rank; dim++) {
+            currentOffset[dim] = (int) (remainder / stride[dim]);
+            remainder %= stride[dim];
+        }
+    }
+
+    /**
+     * Return next chunk of maxChunkElems in array of given shape starting from current offset in the array
+     */
+    private int[] getChunkShape() {
+        int[] chunkShape = new int[rank];
+
+        for (int iDim = 0; iDim < rank; ++iDim) {
+            int size = (int) (maxChunkElems / stride[iDim]);
+            size = (size == 0) ? 1 : size;
+            size = Math.min(size, shape[iDim] - currentOffset[iDim]);
+            chunkShape[iDim] = size;
+        }
+
+        return chunkShape;
+    }
+
+    /**
+     * Build array of strides used to calculate the starting position of each dimension in a 1D backing
+     * array of shape {@code shape}
+     */
+    private long[] buildStride(int[] shape) {
+        long[] result = new long[shape.length];
+
+        long stride = 1;
+
+        for (int dim=shape.length-1; dim>=0; dim--) {
+            result[dim] = stride;
+            stride *= shape[dim];
+        }
+
+        return result;
+    }
+
+    /**
+     * Calculate the number of elements in an array of shape {@code shape}
+     */
+    private long calcSize(int[] shape) {
+        long result = 1L;
+
+        for (int dim=0; dim<shape.length; dim++) {
+            result *= shape[dim];
+        }
+
+        return result;
+    }
+
+}

--- a/src/extension/wps/src/test/java/au/org/emii/aggregator/index/IndexChunkIteratorTest.java
+++ b/src/extension/wps/src/test/java/au/org/emii/aggregator/index/IndexChunkIteratorTest.java
@@ -1,0 +1,163 @@
+package au.org.emii.aggregator.index;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import ucar.ma2.InvalidRangeException;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+public class IndexChunkIteratorTest {
+
+    private static final Object[] TEST_1D_REGULAR_CHUNKS = {
+        new int[][][]{
+            {{0}, {2}},
+            {{2}, {2}},
+            {{4}, {2}},
+            {{6}, {2}},
+            {{8}, {2}}
+        }, new int[]{10}, 2 };
+
+    private static final Object[] TEST_1D_OVERSIZED_CHUNKS = {
+        new int[][][]{
+            {{0}, {5}}
+        }, new int[]{5}, 7};
+
+    private static final Object[] TEST_1D_IRREGULAR_CHUNKS = {
+        new int[][][]{
+            {{0}, {2}},
+            {{2}, {2}},
+            {{4}, {1}}},
+        new int[]{5}, 2};
+
+    private static final Object[] TEST_2D_REGULAR_CHUNKS = {
+        new int[][][]{
+            {{0, 0}, {1, 2}},
+            {{0, 2}, {1, 2}},
+            {{1, 0}, {1, 2}},
+            {{1, 2}, {1, 2}}
+        },
+        new int[]{2, 4}, 2
+    };
+
+    private static final Object[] TEST_2D_IRREGULAR_CHUNKS = {
+        new int[][][]{
+            {{0, 0}, {1, 2}},
+            {{0, 2}, {1, 2}},
+            {{0, 4}, {1, 1}},
+            {{1, 0}, {1, 2}},
+            {{1, 2}, {1, 2}},
+            {{1, 4}, {1, 1}}
+        },
+        new int[]{2, 5}, 2
+    };
+
+    private static final Object[] TEST_2D_OVERSIZE_CHUNKS = {
+        new int[][][]{
+            {{0, 0}, {1, 5}},
+            {{1, 0}, {1, 5}}
+        },
+        new int[]{2, 5}, 7
+    };
+
+    private static final Object[] TEST_3D_REGULAR_CHUNKS = {
+        new int[][][]{
+            {{0, 0, 0}, {1, 1, 2}},
+            {{0, 0, 2}, {1, 1, 2}},
+            {{0, 1, 0}, {1, 1, 2}},
+            {{0, 1, 2}, {1, 1, 2}},
+            {{0, 2, 0}, {1, 1, 2}},
+            {{0, 2, 2}, {1, 1, 2}},
+            {{1, 0, 0}, {1, 1, 2}},
+            {{1, 0, 2}, {1, 1, 2}},
+            {{1, 1, 0}, {1, 1, 2}},
+            {{1, 1, 2}, {1, 1, 2}},
+            {{1, 2, 0}, {1, 1, 2}},
+            {{1, 2, 2}, {1, 1, 2}}
+        },
+        new int[]{2, 3, 4}, 2
+    };
+
+    private static final Object[] TEST_3D_IRREGULAR_CHUNKS = {
+        new int[][][]{
+            {{0, 0, 0}, {1, 1, 3}},
+            {{0, 0, 3}, {1, 1, 1}},
+            {{0, 1, 0}, {1, 1, 3}},
+            {{0, 1, 3}, {1, 1, 1}},
+            {{0, 2, 0}, {1, 1, 3}},
+            {{0, 2, 3}, {1, 1, 1}},
+            {{1, 0, 0}, {1, 1, 3}},
+            {{1, 0, 3}, {1, 1, 1}},
+            {{1, 1, 0}, {1, 1, 3}},
+            {{1, 1, 3}, {1, 1, 1}},
+            {{1, 2, 0}, {1, 1, 3}},
+            {{1, 2, 3}, {1, 1, 1}}
+        },
+        new int[]{2, 3, 4}, 3
+    };
+
+    private static final Object[] TEST_3D_OVERSIZE_CHUNKS = {
+        new int[][][]{
+            {{0, 0, 0}, {1, 3, 4}},
+            {{1, 0, 0}, {1, 3, 4}}
+        },
+        new int[]{2, 3, 4}, 15
+    };
+
+    @Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+            TEST_1D_REGULAR_CHUNKS,
+            TEST_1D_OVERSIZED_CHUNKS,
+            TEST_1D_IRREGULAR_CHUNKS,
+            TEST_2D_REGULAR_CHUNKS,
+            TEST_2D_IRREGULAR_CHUNKS,
+            TEST_2D_OVERSIZE_CHUNKS,
+            TEST_3D_REGULAR_CHUNKS,
+            TEST_3D_IRREGULAR_CHUNKS,
+            TEST_3D_OVERSIZE_CHUNKS
+        });
+    }
+
+    private final int[][][] expected;
+    private final int[] shape;
+    private final int maxChunkElems;
+
+    public IndexChunkIteratorTest(int[][][] expected, int[] shape, int maxChunkElems) {
+        this.expected = expected;
+        this.shape = shape;
+        this.maxChunkElems = maxChunkElems;
+    }
+
+    @Test
+    public void testChunking() throws InvalidRangeException {
+        IndexChunkIterator index = new IndexChunkIterator(shape, maxChunkElems);
+
+        List<int[][]> result = new ArrayList<>();
+
+        while (index.hasNext()) {
+            IndexChunk next = index.next();
+            int[][] iterationResult = new int[2][];
+            iterationResult[0] = next.getOffset();
+            iterationResult[1] = next.getShape();
+            result.add(iterationResult);
+        }
+
+        assertEquals(expected.length, result.size());
+
+        for (int i=0; i<expected.length; i++) {
+            int[][] iterationResult = result.get(i);
+            int[][] iterationExpected = expected[i];
+            assertArrayEquals(iterationExpected[0], iterationResult[0]);
+            assertArrayEquals(iterationExpected[1], iterationResult[1]);
+        }
+    }
+}


### PR DESCRIPTION
Use an IndexChunkIterator using long 1D offsets to read/write variable values one chunk of values at a time instead of ChunkingIndex which doesn't.