### PR TITLE
Remove use of problematic shaded netcdfAll dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,11 +78,6 @@
             </dependency>
             <dependency>
                 <groupId>edu.ucar</groupId>
-                <artifactId>netcdfAll</artifactId>
-                <version>${netcdf.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>edu.ucar</groupId>
                 <artifactId>cdm</artifactId>
                 <version>${netcdf.version}</version>
             </dependency>

--- a/src/extension/wps/pom.xml
+++ b/src/extension/wps/pom.xml
@@ -53,6 +53,10 @@
             <version>9.4-1201-jdbc41</version>
         </dependency>
         <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
@@ -73,6 +77,10 @@
             <groupId>au.org.emii</groupId>
             <artifactId>netcdf-iterator</artifactId>
             <version>1.0.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>edu.ucar</groupId>
+            <artifactId>cdm</artifactId>
         </dependency>
         <dependency>
             <groupId>au.org.emii.core</groupId>


### PR DESCRIPTION
This dependency includes old versions of libraries such as the aws sdk's which causes issues for clients that use it.

Required change to go with https://github.com/aodn/netcdf-iterator/pull/6