### PR TITLE
Prototype for z (depth) parameter subsetting

### DIFF
--- a/src/aggregator/src/main/java/au/org/emii/aggregator/dataset/AbstractNetcdfDataset.java
+++ b/src/aggregator/src/main/java/au/org/emii/aggregator/dataset/AbstractNetcdfDataset.java
@@ -55,7 +55,7 @@ public abstract class AbstractNetcdfDataset implements NetcdfDatasetIF {
 
     @Override
     public NetcdfVariable getVerticalAxis() {
-        return findVariable(AxisType.GeoZ);
+        return findVariable(AxisType.Height);
     }
 
     @Override

--- a/src/aggregator/src/main/java/au/org/emii/aggregator/template/TemplateDataset.java
+++ b/src/aggregator/src/main/java/au/org/emii/aggregator/template/TemplateDataset.java
@@ -37,7 +37,7 @@ public class TemplateDataset extends AbstractNetcdfDataset {
     public TemplateDataset(NetcdfDatasetIF dataset, AggregationOverrides aggregationOverrides,
                            CalendarDateRange timeRange, Range verticalSubset, LatLonRect bbox) {
 
-        this.globalAttributes = getGlobalAttributes(dataset, aggregationOverrides.getAttributeOverrides(), timeRange);
+        this.globalAttributes = getGlobalAttributes(dataset, aggregationOverrides.getAttributeOverrides(), timeRange, verticalSubset);
 
         // Determine variables/dimensions to add
 
@@ -92,7 +92,7 @@ public class TemplateDataset extends AbstractNetcdfDataset {
     }
 
     private List<Attribute> getGlobalAttributes(NetcdfDatasetIF dataset, GlobalAttributeOverrides attributeOverrides,
-                                                CalendarDateRange timeRange) {
+                                                CalendarDateRange timeRange, Range verticalSubset) {
         // Copy existing attributes
 
         Map<String, Attribute> result = new LinkedHashMap<>();
@@ -105,7 +105,7 @@ public class TemplateDataset extends AbstractNetcdfDataset {
 
         // Apply attribute overrides
 
-        Map<String, String> commonSubstitutionValues = getSubstitutionValues(dataset, timeRange);
+        Map<String, String> commonSubstitutionValues = getSubstitutionValues(dataset, timeRange, verticalSubset);
 
         for (GlobalAttributeOverride override: attributeOverrides.getAddOrReplaceAttributes()) {
             String attributeName = override.getName();
@@ -143,7 +143,7 @@ public class TemplateDataset extends AbstractNetcdfDataset {
         return new ArrayList<>(result.values());
     }
 
-    private Map<String, String> getSubstitutionValues(NetcdfDatasetIF dataset, CalendarDateRange timeRange) {
+    private Map<String, String> getSubstitutionValues(NetcdfDatasetIF dataset, CalendarDateRange timeRange, Range verticalRange) {
         Map<String, String> result = new LinkedHashMap<>();
 
         LatLonRect newBbox = dataset.getBbox();
@@ -156,6 +156,11 @@ public class TemplateDataset extends AbstractNetcdfDataset {
         if (timeRange != null) {
             result.put("TIME_START", timeRange.getStart().toString());
             result.put("TIME_END", timeRange.getEnd().toString());
+        }
+
+        if (verticalRange != null) {
+            result.put("Z_MIN", Integer.toString(verticalRange.first()));
+            result.put("Z_MAX", Integer.toString(verticalRange.last()));
         }
 
         CalendarDate aggregationTime = CalendarDate.of(new Date()).truncate(Field.Minute); // ignore seconds/milliseconds

--- a/src/extension/wps/src/test/java/au/org/emii/wps/gogoduck/parameter/SubsetParametersTest.java
+++ b/src/extension/wps/src/test/java/au/org/emii/wps/gogoduck/parameter/SubsetParametersTest.java
@@ -11,7 +11,7 @@ public class SubsetParametersTest {
 
     @Test
     public void testParameterParsing() {
-        SubsetParameters sp = SubsetParameters.parse("TIME,2009-01-01T00:00:00.000Z,2009-12-25T23:04:00.000Z;LATITUDE,-33.433849,-32.150743;LONGITUDE,114.15197,115.741219");
+        SubsetParameters sp = SubsetParameters.parse("TIME,2009-01-01T00:00:00.000Z,2009-12-25T23:04:00.000Z;LATITUDE,-33.433849,-32.150743;LONGITUDE,114.15197,115.741219;DEPTH,0.0,100.0");
 
         assertEquals(sp.getTimeRange().getStart(), CalendarDate.parseISOformat("gregorian", "2009-01-01T00:00:00.000Z"));
         assertEquals(sp.getTimeRange().getEnd(), CalendarDate.parseISOformat("gregorian","2009-12-25T23:04:00.000Z"));
@@ -21,6 +21,9 @@ public class SubsetParametersTest {
 
         assertEquals(sp.getBbox().getLonMin(), 114.15197, 0.000001);
         assertEquals(sp.getBbox().getLonMax(), 115.741219, 0.000001);
+
+        assertEquals(sp.getVerticalRange().first(), 0);
+        assertEquals(sp.getVerticalRange().last(), 100);
     }
 
     @Test
@@ -32,10 +35,19 @@ public class SubsetParametersTest {
     }
 
     @Test
+    public void testValidDepth() {
+        SubsetParameters sp = SubsetParameters.parse("TIME,2009-01-01T00:00:00.000Z,2009-12-25T23:04:00.000Z;LATITUDE,-33.433849,-32.150743;LONGITUDE,114.15197,115.741219;DEPTH,0.0,100.0");
+
+        assertEquals(sp.getVerticalRange().first(), 0);
+        assertEquals(sp.getVerticalRange().last(), 100);
+    }
+
+    @Test
     public void testValidTimeWithoutZ() {
         SubsetParameters sp = SubsetParameters.parse("TIME,2014-10-10T00:00:00,2014-10-12T00:00:00;LATITUDE,-33.433849,-32.150743;LONGITUDE,114.15197,115.741219");
 
         assertEquals(sp.getTimeRange().getStart(), CalendarDate.parseISOformat("gregorian", "2014-10-10T00:00:00Z"));
+        assertTrue(sp.getVerticalRange() == null);
     }
 
     @Test
@@ -55,6 +67,13 @@ public class SubsetParametersTest {
     public void testAllowsMissingTimeSubset() {
         SubsetParameters sp = SubsetParameters.parse("LATITUDE,-33.433849,-32.150743;LONGITUDE,114.15197,115.741219");
         assertTrue(sp.getTimeRange() == null);
+    }
+
+    @Test
+    public void testAllowsMissingTimeSubsetWithZ() {
+        SubsetParameters sp = SubsetParameters.parse("LATITUDE,-33.433849,-32.150743;LONGITUDE,114.15197,115.741219;DEPTH,0.0,100.0");
+        assertTrue(sp.getTimeRange() == null);
+        assertTrue(sp.getVerticalRange() != null);
     }
 
     @Test
@@ -83,6 +102,15 @@ public class SubsetParametersTest {
     }
 
     @Test
+    public void testCatchesInvalidFormatVerticalSubset() {
+        try {
+            SubsetParameters.parse("TIME,2009-01-01T00:00:00.000Z,2009-12-25T23:04:00.000Z;LATITUDE,-33.433849,-32.150743;LONGITUDE,114.15197,115.741219;DEPTH,0.0,FAIL100.0");
+        } catch (Exception e) {
+            assertTrue(e.getMessage().contains("Invalid vertical subset format for subset:"));
+        }
+    }
+
+    @Test
     public void testCatchesInvalidFormatSubset() {
         try {
             SubsetParameters.parse("TIME,2014-10-10T00:00:00,2014-10-12T00:00:00;LATITUDE,-33.433849,-32.150743;LONGITUDEX,114.15197,115.741219");
@@ -104,6 +132,11 @@ public class SubsetParametersTest {
 
         try {
             SubsetParameters.parse("TIME,2014-10-10T00:00:00,2014-10-12T00:00:00;LATITUDE,-33.433849,-32.150743;LONGITUDE,114.15197,115.741219;Something,11,11");
+        } catch (Exception e) {
+            assertTrue(e.getMessage().contains("Invalid format for subset:"));
+        }
+        try {
+            SubsetParameters.parse("TIME,2009-01-01T00:00:00.000Z,2009-12-25T23:04:00.000Z;LATITUDE,-33.433849,-32.150743;LONGITUDE,114.15197,115.741219;DEDERP,0.0,100.0");
         } catch (Exception e) {
             assertTrue(e.getMessage().contains("Invalid format for subset:"));
         }


### PR DESCRIPTION
Linked PR https://github.com/aodn/aws-wps/pull/224
Implements depth (z dimension) as a ucar Range of monotonically increasing integers (based on the skeleton in aws-wps for handling z dimenion.

CARS datasets represent depth as a short variable, which is converted into a Range here (comments  and feedback on this conversion please).

Requires passing `DEPTH,0.0,100.0` as an addition to the subset; can be non-existant, in which case a null z-dimension is added to the subset.