### PR TITLE
Fixes aodn/aodn-portal#2652

### DIFF
--- a/src/extension/wps/src/main/java/au/org/emii/ncdfgenerator/NcdfEncoder.java
+++ b/src/extension/wps/src/main/java/au/org/emii/ncdfgenerator/NcdfEncoder.java
@@ -271,8 +271,11 @@ public class NcdfEncoder implements AutoCloseable {
 
             // TODO more checks around this
             // maybe support converion to ncdf array attribute types
-            rs.next();
-            return rs.getObject(1);
+            if (rs.next()) {
+                return rs.getObject(1);
+            } else {
+                return null;
+            }
         }
         finally {
             if (stmt != null) {

--- a/src/extension/wps/src/test/resources/anmn_ts.xml
+++ b/src/extension/wps/src/test/resources/anmn_ts.xml
@@ -47,6 +47,7 @@
     <attribute name="deployment_code" sql="select deployment_code from $instance"/>
     <attribute name="featureType" value="'timeSeries'"/>
     <attribute name="naming_authority" value="'IMOS'"/>
+    <attribute name="missing_attribute" sql="select 'not possible' from $instance where false"/>
     <attribute name="instrument_serial_number" sql="select instrument_serial_number from $instance"/>
     <attribute name="history" sql="select history from $instance"/>
     <attribute name="geospatial_lat_min">


### PR DESCRIPTION
Was throwing an exception when an attribute sql query returned no results.

Added a check to see if any records are returned before trying to return a value.

A null value is checked before adding the attribute to the file by existing code, and the end result will be that the attribute will not be added to the output file and the missing attribute will be logged.