### PR TITLE
Addresses aodn/backlog#941

### DIFF
--- a/src/extension/ncwms/src/main/java/au/org/emii/geoserver/wms/SimpleKvpParser.java
+++ b/src/extension/ncwms/src/main/java/au/org/emii/geoserver/wms/SimpleKvpParser.java
@@ -1,0 +1,14 @@
+package au.org.emii.geoserver.wms;
+
+import org.geoserver.ows.KvpParser;
+
+public class SimpleKvpParser extends KvpParser {
+    public SimpleKvpParser(String key) {
+        super(key, String.class);
+    }
+
+    @Override
+    public Object parse(String s) throws Exception {
+        return s;
+    }
+}

--- a/src/extension/ncwms/src/main/resources/applicationContext.xml
+++ b/src/extension/ncwms/src/main/resources/applicationContext.xml
@@ -40,10 +40,10 @@
         </constructor-arg>
     </bean>
 
-    <bean id="paletteKvpParser" class="org.geoserver.wms.kvp.PaletteKvpParser">
-        <property name="service" value="WMS"/>
-        <!-- Avoid the palleteKvpParser denying palettes that are not defined
-             in geoserver but may be defined on thredds (ncwms) -->
+    <bean id="ncwmsPaletteKvpParser" class="au.org.emii.geoserver.wms.SimpleKvpParser">
+        <constructor-arg value="palette"/>
+        <property name="service" value="NCWMS"/>
+        <!-- Don't want to use the default PaletteKvpParser -->
     </bean>
 
     <!-- http url mapping -->


### PR DESCRIPTION
Don't override the core PaletteKvpParser bean definition as this requires
context files to be loaded in the right order for it to work and this is outside our control

Instead use a simple parser which just returns the provided string for ncwms PALETTE request parameters