### PR TITLE
Re-enable Geowebcache with S3 support

### DIFF
--- a/src/main/pom.xml
+++ b/src/main/pom.xml
@@ -49,6 +49,11 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>org.geoserver.community</groupId>
+            <artifactId>gs-gwc-s3</artifactId>
+            <version>2.14.1</version>
+        </dependency>
+        <dependency>
             <groupId>net.sourceforge.jtds</groupId>
             <artifactId>jtds</artifactId>
             <version>1.3.1</version>
@@ -86,8 +91,6 @@
                             <artifactId>gs-web-app</artifactId>
                                 <excludes>
                                     <exclude>WEB-INF/lib/postgresql*jdbc*.jar</exclude>
-                                    <exclude>WEB-INF/lib/gwc-*.jar</exclude>
-                                    <exclude>WEB-INF/lib/*-gwc-*.jar</exclude>
                                 </excludes>
                         </overlay>
                     </overlays>

--- a/src/main/pom.xml
+++ b/src/main/pom.xml
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.geoserver.community</groupId>
             <artifactId>gs-gwc-s3</artifactId>
-            <version>2.14.1</version>
+            <version>2.14.2</version>
         </dependency>
         <dependency>
             <groupId>net.sourceforge.jtds</groupId>


### PR DESCRIPTION
~~Note: https://github.com/aodn/geoserver-build/pull/287 the plugin version will need to be updated to align with the Geoserver version if this PR is merged first~~