### PR TITLE
Add Control Flow extension to dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,11 @@
                 <version>${geoserver.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.geoserver.extension</groupId>
+                <artifactId>gs-control-flow</artifactId>
+                <version>${geoserver.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>dom4j</groupId>
                 <artifactId>dom4j</artifactId>
                 <version>1.6.1</version>


### PR DESCRIPTION
If there is no config, this module is not activated at Geoserver startup.

An example configuration file is in a draft PR: https://github.com/aodn/geoserver-config/pull/615, but this should probably be provisioned during deployment, since the values should be tuned based on the environment capacity.