### PR TITLE
Replace Travis CI with Github Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-16.04
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Cache Maven packages
         uses: actions/cache@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,19 @@
+name: geoserver-build
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-16.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache Maven packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Run the Maven install phase
+        run: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+      - name: Run the Maven test phase
+        run: mvn test -B

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-dist: trusty
-sudo: false
-language: java
-
-cache:
-  directories:
-    - $HOME/.m2
-

--- a/pom.xml
+++ b/pom.xml
@@ -83,21 +83,19 @@
      <repositories>
          <repository>
              <id>mvnrepository</id>
-             <url>http://mvnrepository.com/artifact/</url>
+             <url>https://mvnrepository.com/artifact/</url>
          </repository>
        <repository>
             <id>central</id>
-            <url>http://central.maven.org/maven2/</url>
+            <url>https://repo1.maven.org/maven2/</url>
         </repository>
-        <repository>
-            <id>opengeo</id>
-            <url>http://repo.boundlessgeo.com/main</url>
-        </repository>
-        <repository>
-            <id>osgeo</id>
-            <name>Open Source Geospatial Foundation Repository</name>
-            <url>http://download.osgeo.org/webdav/geotools/</url>
-        </repository>
+         <repository>
+             <id>osgeo</id>
+             <name>OSGeo Release Repository</name>
+             <url>https://repo.osgeo.org/repository/release/</url>
+             <snapshots><enabled>false</enabled></snapshots>
+             <releases><enabled>true</enabled></releases>
+         </repository>
     </repositories>
 
     <distributionManagement>


### PR DESCRIPTION
For https://github.com/aodn/issues/issues/940

It's failing in the same way as the travis build is: ```Error:  Non-resolvable import POM: Could not transfer artifact org.geoserver:geoserver:pom:2.15.0 from/to mvnrepository (http://mvnrepository.com/artifact/): Authorization failed for http://mvnrepository.com/artifact/org/geoserver/geoserver/2.15.0/geoserver-2.15.0.pom 403 Forbidden @ line 29, column 25```

Since this task is just to lift and shift travis builds to github actions I think we'll have to just accept it like that.
