### PR TITLE
Revert "Use correct default when json col is null"

### DIFF
--- a/src/extension/csv-with-metadata-header/src/main/java/au/org/emii/geoserver/wfs/response/CsvPivotedFeatureCollectionSource.java
+++ b/src/extension/csv-with-metadata-header/src/main/java/au/org/emii/geoserver/wfs/response/CsvPivotedFeatureCollectionSource.java
@@ -176,7 +176,7 @@ public class CsvPivotedFeatureCollectionSource implements CsvSource {
                 }
             } else {
                 for (String key : this.pivotColumnNames.stream().sorted().collect(Collectors.toList())) {
-                    result.add(this.pivotConfig.getDefaultValue());
+                    result.add("");
                 }
             }
         }


### PR DESCRIPTION
Reverts aodn/geoserver-build#317
The previous behaviour was correct (see https://github.com/aodn/backlog/issues/3426#issuecomment-937493249)